### PR TITLE
Add DecisionNumbers module

### DIFF
--- a/DogrudanTeminParadiseAPI/Controllers/DecisionNumbersController.cs
+++ b/DogrudanTeminParadiseAPI/Controllers/DecisionNumbersController.cs
@@ -1,0 +1,58 @@
+using DogrudanTeminParadiseAPI.Dto;
+using DogrudanTeminParadiseAPI.Helpers.Attributes;
+using DogrudanTeminParadiseAPI.Service.Abstract;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DogrudanTeminParadiseAPI.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    [CallLogs]
+    public class DecisionNumbersController : ControllerBase
+    {
+        private readonly IDecisionNumbersService _svc;
+        public DecisionNumbersController(IDecisionNumbersService svc) => _svc = svc;
+
+        [HttpPost]
+        [Authorize]
+        public async Task<IActionResult> Create([FromBody] CreateDecisionNumbersDto dto)
+        {
+            var created = await _svc.CreateAsync(dto);
+            return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> GetAll() => Ok(await _svc.GetAllAsync());
+
+        [HttpGet("{id}")]
+        public async Task<IActionResult> GetById(Guid id)
+        {
+            var item = await _svc.GetByIdAsync(id);
+            return item == null ? NotFound() : Ok(item);
+        }
+
+        [HttpPut("{id}")]
+        [Authorize]
+        public async Task<IActionResult> Update(Guid id, [FromBody] UpdateDecisionNumbersDto dto)
+        {
+            var updated = await _svc.UpdateAsync(id, dto);
+            return updated == null ? NotFound() : Ok(updated);
+        }
+
+        [HttpDelete("{id}")]
+        [Authorize]
+        public async Task<IActionResult> Delete(Guid id)
+        {
+            try
+            {
+                await _svc.DeleteAsync(id);
+                return NoContent();
+            }
+            catch (KeyNotFoundException ex)
+            {
+                return NotFound(new { error = ex.Message });
+            }
+        }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Dto/CreateDecisionNumbersDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/CreateDecisionNumbersDto.cs
@@ -1,0 +1,10 @@
+using DogrudanTeminParadiseAPI.Helpers;
+
+namespace DogrudanTeminParadiseAPI.Dto
+{
+    public class CreateDecisionNumbersDto
+    {
+        public ProcurementNumbers ProcurementNumbers { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Dto/DecisionNumbersDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/DecisionNumbersDto.cs
@@ -1,0 +1,11 @@
+using DogrudanTeminParadiseAPI.Helpers;
+
+namespace DogrudanTeminParadiseAPI.Dto
+{
+    public class DecisionNumbersDto
+    {
+        public string Id { get; set; }
+        public ProcurementNumbers ProcurementNumbers { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Dto/UpdateDecisionNumbersDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/UpdateDecisionNumbersDto.cs
@@ -1,0 +1,10 @@
+using DogrudanTeminParadiseAPI.Helpers;
+
+namespace DogrudanTeminParadiseAPI.Dto
+{
+    public class UpdateDecisionNumbersDto
+    {
+        public ProcurementNumbers ProcurementNumbers { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Filter/DbInstallationWizard.cs
+++ b/DogrudanTeminParadiseAPI/Filter/DbInstallationWizard.cs
@@ -32,7 +32,8 @@ namespace DogrudanTeminParadiseAPI.Filter
             "MarketResearchJuries", "InspectionAcceptanceJuries",
             "InspectionAcceptanceCertificates",
             "AdditionalInspectionAcceptanceCertificates",
-            "ApproximateCostJuries", "ProcurementEntryEditors", "InspectionAcceptanceNotes"
+            "ApproximateCostJuries", "ProcurementEntryEditors", "InspectionAcceptanceNotes",
+            "DecisionNumbers"
         };
 
             // 2) Eksik koleksiyonları yarat

--- a/DogrudanTeminParadiseAPI/Helpers/HelperClasses.cs
+++ b/DogrudanTeminParadiseAPI/Helpers/HelperClasses.cs
@@ -68,4 +68,14 @@ namespace DogrudanTeminParadiseAPI.Helpers
         PRODUCT,
         SERVICE
     }
+
+    public class ProcurementNumbers
+    {
+        public string ProcurementDecisionNumber { get; set; }
+        public string PiyasaArastirmaOnayNumber { get; set; }
+        public string TeklifMektubuNumber { get; set; }
+        public string PiyasaArastirmaBaslangicNumber { get; set; }
+        public string YaklasikMaliyetHesaplamaBaslangicNumber { get; set; }
+        public string MuayeneVeKabulBelgesiNumber { get; set; }
+    }
 }

--- a/DogrudanTeminParadiseAPI/Mapping/MappingProfile.cs
+++ b/DogrudanTeminParadiseAPI/Mapping/MappingProfile.cs
@@ -160,6 +160,10 @@ namespace DogrudanTeminParadiseAPI.Mapping
             CreateMap<UserFeatures, UserFeaturesDto>()
                 .ForMember(dest => dest.Id, opt => opt.MapFrom(src => Guid.Parse(src.Id)));
             CreateMap<Feature, FeatureDto>();
+
+            CreateMap<CreateDecisionNumbersDto, DecisionNumbers>();
+            CreateMap<UpdateDecisionNumbersDto, DecisionNumbers>();
+            CreateMap<DecisionNumbers, DecisionNumbersDto>();
         }
     }
 }

--- a/DogrudanTeminParadiseAPI/Models/DecisionNumbers.cs
+++ b/DogrudanTeminParadiseAPI/Models/DecisionNumbers.cs
@@ -1,0 +1,17 @@
+using DogrudanTeminParadiseAPI.Helpers;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace DogrudanTeminParadiseAPI.Models
+{
+    public class DecisionNumbers
+    {
+        [BsonId]
+        [BsonRepresentation(BsonType.String)]
+        public string Id { get; set; }
+
+        public ProcurementNumbers ProcurementNumbers { get; set; } = new();
+
+        public string Name { get; set; }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Program.cs
+++ b/DogrudanTeminParadiseAPI/Program.cs
@@ -81,6 +81,7 @@ builder.Services.AddScoped(sp => new MongoDBRepository<BackupProcurementEntry>(c
 builder.Services.AddScoped(sp => new MongoDBRepository<BackupProcurementEntryEditor>(cfg["MongoAPI"], cfg["MongoBackupDBName"], "BackupProcurementEntryEditors"));
 builder.Services.AddScoped(sp => new MongoDBRepository<InspectionAcceptanceNote>(cfg["MongoAPI"], cfg["MongoDBName"], "InspectionAcceptanceNotes"));
 builder.Services.AddScoped(sp => new MongoDBRepository<UserOwnFeaturesList>(cfg["MongoAPI"], cfg["MongoDBName"], "UserOwnFeaturesLists"));
+builder.Services.AddScoped(sp => new MongoDBRepository<DecisionNumbers>(cfg["MongoAPI"], cfg["MongoDBName"], "DecisionNumbers"));
 
 builder.Services.AddSingleton<IMongoClient>(sp =>
     new MongoClient(cfg["MongoAPI"])
@@ -126,6 +127,7 @@ builder.Services.AddScoped<IUserService, UserService>();
 builder.Services.AddScoped<IAuthenticationService, AuthenticationService>();
 builder.Services.AddScoped<IInspectionAcceptanceNoteService, InspectionAcceptanceNoteService>();
 builder.Services.AddScoped<IUserOwnFeaturesListService, UserOwnFeaturesListService>();
+builder.Services.AddScoped<IDecisionNumbersService, DecisionNumbersService>();
 // Factoryler
 builder.Services.AddSingleton<ITeminApiExceptionFactory, TeminApiExceptionFactory>();
 

--- a/DogrudanTeminParadiseAPI/Service/Abstract/IDecisionNumbersService.cs
+++ b/DogrudanTeminParadiseAPI/Service/Abstract/IDecisionNumbersService.cs
@@ -1,0 +1,13 @@
+using DogrudanTeminParadiseAPI.Dto;
+
+namespace DogrudanTeminParadiseAPI.Service.Abstract
+{
+    public interface IDecisionNumbersService
+    {
+        Task<DecisionNumbersDto> CreateAsync(CreateDecisionNumbersDto dto);
+        Task<IEnumerable<DecisionNumbersDto>> GetAllAsync();
+        Task<DecisionNumbersDto?> GetByIdAsync(Guid id);
+        Task<DecisionNumbersDto?> UpdateAsync(Guid id, UpdateDecisionNumbersDto dto);
+        Task DeleteAsync(Guid id);
+    }
+}

--- a/DogrudanTeminParadiseAPI/Service/Concrete/DecisionNumbersService.cs
+++ b/DogrudanTeminParadiseAPI/Service/Concrete/DecisionNumbersService.cs
@@ -1,0 +1,56 @@
+using AutoMapper;
+using DogrudanTeminParadiseAPI.Dto;
+using DogrudanTeminParadiseAPI.Models;
+using DogrudanTeminParadiseAPI.Repositories;
+using DogrudanTeminParadiseAPI.Service.Abstract;
+
+namespace DogrudanTeminParadiseAPI.Service.Concrete
+{
+    public class DecisionNumbersService : IDecisionNumbersService
+    {
+        private readonly MongoDBRepository<DecisionNumbers> _repo;
+        private readonly IMapper _mapper;
+
+        public DecisionNumbersService(MongoDBRepository<DecisionNumbers> repo, IMapper mapper)
+        {
+            _repo = repo;
+            _mapper = mapper;
+        }
+
+        public async Task<DecisionNumbersDto> CreateAsync(CreateDecisionNumbersDto dto)
+        {
+            var entity = _mapper.Map<DecisionNumbers>(dto);
+            entity.Id = Guid.NewGuid().ToString();
+            await _repo.InsertAsync(entity);
+            return _mapper.Map<DecisionNumbersDto>(entity);
+        }
+
+        public async Task<IEnumerable<DecisionNumbersDto>> GetAllAsync()
+        {
+            var list = await _repo.GetAllAsync();
+            return list.Select(_mapper.Map<DecisionNumbersDto>);
+        }
+
+        public async Task<DecisionNumbersDto?> GetByIdAsync(Guid id)
+        {
+            var e = await _repo.GetByIdAsync(id);
+            return e == null ? null : _mapper.Map<DecisionNumbersDto>(e);
+        }
+
+        public async Task<DecisionNumbersDto?> UpdateAsync(Guid id, UpdateDecisionNumbersDto dto)
+        {
+            var existing = await _repo.GetByIdAsync(id);
+            if (existing == null)
+                return null;
+            _mapper.Map(dto, existing);
+            await _repo.UpdateAsync(id, existing);
+            return _mapper.Map<DecisionNumbersDto>(existing);
+        }
+
+        public async Task DeleteAsync(Guid id)
+        {
+            var existing = await _repo.GetByIdAsync(id) ?? throw new KeyNotFoundException("DecisionNumbers not found.");
+            await _repo.DeleteAsync(id);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `ProcurementNumbers` helper class
- create `DecisionNumbers` model and DTOs
- implement controller, service, and interface for decision numbers
- register repository and service in DI
- extend AutoMapper profile
- update database installation wizard for new collection

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686baaf1ef0c8323bf08e3de1b416379