### PR TITLE
Implement notification backup and adjust modules

### DIFF
--- a/DogrudanTeminParadiseAPI/Controllers/BackupUserNotificationController.cs
+++ b/DogrudanTeminParadiseAPI/Controllers/BackupUserNotificationController.cs
@@ -1,0 +1,46 @@
+using DogrudanTeminParadiseAPI.Dto;
+using DogrudanTeminParadiseAPI.Helpers.Attributes;
+using DogrudanTeminParadiseAPI.Service.Abstract;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DogrudanTeminParadiseAPI.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    [Authorize]
+    [CallLogs]
+    public class BackupUserNotificationController : ControllerBase
+    {
+        private readonly IBackupUserNotificationService _svc;
+        public BackupUserNotificationController(IBackupUserNotificationService svc) => _svc = svc;
+
+        [HttpPost]
+        public async Task<IActionResult> Create([FromBody] CreateBackupUserNotificationDto dto)
+        {
+            var created = await _svc.CreateAsync(dto);
+            return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> GetAll()
+        {
+            var list = await _svc.GetAllAsync();
+            return Ok(list);
+        }
+
+        [HttpGet("{id}")]
+        public async Task<IActionResult> GetById(Guid id)
+        {
+            var dto = await _svc.GetByIdAsync(id);
+            return dto == null ? NotFound() : Ok(dto);
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(Guid id)
+        {
+            await _svc.DeleteAsync(id);
+            return NoContent();
+        }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Controllers/SharedProcurementEntryController.cs
+++ b/DogrudanTeminParadiseAPI/Controllers/SharedProcurementEntryController.cs
@@ -1,0 +1,33 @@
+using DogrudanTeminParadiseAPI.Dto;
+using DogrudanTeminParadiseAPI.Helpers.Attributes;
+using DogrudanTeminParadiseAPI.Service.Abstract;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DogrudanTeminParadiseAPI.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    [Authorize]
+    [CallLogs]
+    public class SharedProcurementEntryController : ControllerBase
+    {
+        private readonly ISharedProcurementEntryService _svc;
+        public SharedProcurementEntryController(ISharedProcurementEntryService svc) => _svc = svc;
+
+        [HttpPost]
+        public async Task<IActionResult> Create([FromBody] CreateSharedProcurementEntryDto dto)
+        {
+            var created = await _svc.CreateAsync(dto);
+            return CreatedAtAction(nameof(GetByUser), new { userId = created.ProcurementSharerUserId }, created);
+        }
+
+        [HttpGet("user/{userId}")]
+        public async Task<IActionResult> GetByUser(Guid userId)
+        {
+            var list = await _svc.GetByUserAsync(userId);
+            return Ok(list);
+        }
+
+    }
+}

--- a/DogrudanTeminParadiseAPI/Controllers/UserNotificationController.cs
+++ b/DogrudanTeminParadiseAPI/Controllers/UserNotificationController.cs
@@ -1,0 +1,62 @@
+using DogrudanTeminParadiseAPI.Dto;
+using DogrudanTeminParadiseAPI.Helpers.Attributes;
+using DogrudanTeminParadiseAPI.Service.Abstract;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+
+namespace DogrudanTeminParadiseAPI.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    [Authorize]
+    [CallLogs]
+    public class UserNotificationController : ControllerBase
+    {
+        private readonly IUserNotificationService _svc;
+        public UserNotificationController(IUserNotificationService svc) => _svc = svc;
+
+        [HttpPost]
+        public async Task<IActionResult> Create([FromBody] CreateUserNotificationDto dto)
+        {
+            var created = await _svc.CreateAsync(dto);
+            return CreatedAtAction(nameof(Get), new { }, created);
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> Get([FromQuery] UserNotificationQueryDto q)
+        {
+            var list = await _svc.GetAsync(q);
+            return Ok(list);
+        }
+
+        [HttpPut("{id}")]
+        public async Task<IActionResult> Update(Guid id, [FromBody] UpdateUserNotificationDto dto)
+        {
+            try
+            {
+                var updated = await _svc.UpdateAsync(id, dto);
+                return Ok(updated);
+            }
+            catch (KeyNotFoundException ex)
+            {
+                return NotFound(new { error = ex.Message });
+            }
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(Guid id)
+        {
+            try
+            {
+                var userId = Guid.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier));
+                await _svc.DeleteAsync(id, userId);
+                return NoContent();
+            }
+            catch (KeyNotFoundException ex)
+            {
+                return NotFound(new { error = ex.Message });
+            }
+        }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Dto/BackupUserNotificationDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/BackupUserNotificationDto.cs
@@ -1,0 +1,20 @@
+using DogrudanTeminParadiseAPI.Filter;
+using System.Text.Json.Serialization;
+
+namespace DogrudanTeminParadiseAPI.Dto
+{
+    public class BackupUserNotificationDto
+    {
+        public Guid Id { get; set; }
+        public Guid NotificationFromUser { get; set; }
+        public Guid NotificationToUser { get; set; }
+        public string NotificationHeader { get; set; }
+        public string NotificationIcon { get; set; }
+        public string NotificationText { get; set; }
+        public DateTime NotificationDate { get; set; }
+        public Guid RemovedByUserId { get; set; }
+
+        [JsonConverter(typeof(TurkeyDateTimeConverter))]
+        public DateTime RemovingDate { get; set; }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Dto/CreateBackupUserNotificationDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/CreateBackupUserNotificationDto.cs
@@ -1,0 +1,19 @@
+using DogrudanTeminParadiseAPI.Filter;
+using System.Text.Json.Serialization;
+
+namespace DogrudanTeminParadiseAPI.Dto
+{
+    public class CreateBackupUserNotificationDto
+    {
+        public Guid NotificationFromUser { get; set; }
+        public Guid NotificationToUser { get; set; }
+        public string NotificationHeader { get; set; }
+        public string NotificationIcon { get; set; }
+        public string NotificationText { get; set; }
+        public DateTime NotificationDate { get; set; }
+        public Guid RemovedByUserId { get; set; }
+
+        [JsonConverter(typeof(TurkeyDateTimeConverter))]
+        public DateTime RemovingDate { get; set; }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Dto/CreateSharedProcurementEntryDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/CreateSharedProcurementEntryDto.cs
@@ -1,0 +1,9 @@
+namespace DogrudanTeminParadiseAPI.Dto
+{
+    public class CreateSharedProcurementEntryDto
+    {
+        public Guid ProcurementSharerUserId { get; set; }
+        public Guid ProcurementId { get; set; }
+        public List<Guid> SharedToUserIds { get; set; } = new();
+    }
+}

--- a/DogrudanTeminParadiseAPI/Dto/CreateUserNotificationDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/CreateUserNotificationDto.cs
@@ -1,0 +1,12 @@
+namespace DogrudanTeminParadiseAPI.Dto
+{
+    public class CreateUserNotificationDto
+    {
+        public Guid NotificationFromUser { get; set; }
+        public Guid NotificationToUser { get; set; }
+        public string NotificationHeader { get; set; }
+        public string NotificationIcon { get; set; }
+        public string NotificationText { get; set; }
+        public bool IsMarkAsUnread { get; set; } = true;
+    }
+}

--- a/DogrudanTeminParadiseAPI/Dto/SharedProcurementEntryDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/SharedProcurementEntryDto.cs
@@ -1,0 +1,11 @@
+namespace DogrudanTeminParadiseAPI.Dto
+{
+    public class SharedProcurementEntryDto
+    {
+        public Guid Id { get; set; }
+        public Guid ProcurementSharerUserId { get; set; }
+        public Guid ProcurementId { get; set; }
+        public List<Guid> SharedToUserIds { get; set; }
+        public DateTime SharingDate { get; set; }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Dto/UpdateUserNotificationDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/UpdateUserNotificationDto.cs
@@ -1,0 +1,7 @@
+namespace DogrudanTeminParadiseAPI.Dto
+{
+    public class UpdateUserNotificationDto
+    {
+        public bool IsMarkAsUnread { get; set; }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Dto/UserNotificationDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/UserNotificationDto.cs
@@ -1,0 +1,14 @@
+namespace DogrudanTeminParadiseAPI.Dto
+{
+    public class UserNotificationDto
+    {
+        public Guid Id { get; set; }
+        public Guid NotificationFromUser { get; set; }
+        public Guid NotificationToUser { get; set; }
+        public string NotificationHeader { get; set; }
+        public string NotificationIcon { get; set; }
+        public string NotificationText { get; set; }
+        public DateTime NotificationDate { get; set; }
+        public bool IsMarkAsUnread { get; set; }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Dto/UserNotificationQueryDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/UserNotificationQueryDto.cs
@@ -1,0 +1,11 @@
+namespace DogrudanTeminParadiseAPI.Dto
+{
+    public class UserNotificationQueryDto
+    {
+        public DateTime? FromDate { get; set; }
+        public DateTime? ToDate { get; set; }
+        public List<Guid>? ToUsers { get; set; }
+        public string? Header { get; set; }
+        public int Top { get; set; } = 100;
+    }
+}

--- a/DogrudanTeminParadiseAPI/Mapping/MappingProfile.cs
+++ b/DogrudanTeminParadiseAPI/Mapping/MappingProfile.cs
@@ -164,6 +164,17 @@ namespace DogrudanTeminParadiseAPI.Mapping
             CreateMap<CreateDecisionNumbersDto, DecisionNumbers>();
             CreateMap<UpdateDecisionNumbersDto, DecisionNumbers>();
             CreateMap<DecisionNumbers, DecisionNumbersDto>();
+
+            CreateMap<CreateSharedProcurementEntryDto, SharedProcurementEntry>();
+            CreateMap<SharedProcurementEntry, SharedProcurementEntryDto>();
+
+            CreateMap<CreateUserNotificationDto, UserNotification>();
+            CreateMap<UpdateUserNotificationDto, UserNotification>();
+            CreateMap<UserNotification, UserNotificationDto>();
+
+            CreateMap<CreateBackupUserNotificationDto, BackupUserNotification>();
+            CreateMap<BackupUserNotification, BackupUserNotificationDto>();
+            CreateMap<UserNotification, BackupUserNotification>();
         }
     }
 }

--- a/DogrudanTeminParadiseAPI/Models/BackupUserNotification.cs
+++ b/DogrudanTeminParadiseAPI/Models/BackupUserNotification.cs
@@ -1,0 +1,27 @@
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace DogrudanTeminParadiseAPI.Models
+{
+    public class BackupUserNotification
+    {
+        [BsonId]
+        [BsonRepresentation(BsonType.String)]
+        public Guid Id { get; set; }
+
+        [BsonRepresentation(BsonType.String)]
+        public Guid NotificationFromUser { get; set; }
+
+        [BsonRepresentation(BsonType.String)]
+        public Guid NotificationToUser { get; set; }
+
+        public string NotificationHeader { get; set; }
+        public string NotificationIcon { get; set; }
+        public string NotificationText { get; set; }
+        public DateTime NotificationDate { get; set; }
+
+        [BsonRepresentation(BsonType.String)]
+        public Guid RemovedByUserId { get; set; }
+        public DateTime RemovingDate { get; set; }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Models/SharedProcurementEntry.cs
+++ b/DogrudanTeminParadiseAPI/Models/SharedProcurementEntry.cs
@@ -1,0 +1,23 @@
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace DogrudanTeminParadiseAPI.Models
+{
+    public class SharedProcurementEntry
+    {
+        [BsonId]
+        [BsonRepresentation(BsonType.String)]
+        public Guid Id { get; set; }
+
+        [BsonRepresentation(BsonType.String)]
+        public Guid ProcurementSharerUserId { get; set; }
+
+        [BsonRepresentation(BsonType.String)]
+        public Guid ProcurementId { get; set; }
+
+        [BsonRepresentation(BsonType.String)]
+        public List<Guid> SharedToUserIds { get; set; } = new();
+
+        public DateTime SharingDate { get; set; }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Models/UserNotification.cs
+++ b/DogrudanTeminParadiseAPI/Models/UserNotification.cs
@@ -1,0 +1,24 @@
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace DogrudanTeminParadiseAPI.Models
+{
+    public class UserNotification
+    {
+        [BsonId]
+        [BsonRepresentation(BsonType.String)]
+        public Guid Id { get; set; }
+
+        [BsonRepresentation(BsonType.String)]
+        public Guid NotificationFromUser { get; set; }
+
+        [BsonRepresentation(BsonType.String)]
+        public Guid NotificationToUser { get; set; }
+
+        public string NotificationHeader { get; set; }
+        public string NotificationIcon { get; set; }
+        public string NotificationText { get; set; }
+        public DateTime NotificationDate { get; set; }
+        public bool IsMarkAsUnread { get; set; }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Program.cs
+++ b/DogrudanTeminParadiseAPI/Program.cs
@@ -82,6 +82,9 @@ builder.Services.AddScoped(sp => new MongoDBRepository<BackupProcurementEntryEdi
 builder.Services.AddScoped(sp => new MongoDBRepository<InspectionAcceptanceNote>(cfg["MongoAPI"], cfg["MongoDBName"], "InspectionAcceptanceNotes"));
 builder.Services.AddScoped(sp => new MongoDBRepository<UserOwnFeaturesList>(cfg["MongoAPI"], cfg["MongoDBName"], "UserOwnFeaturesLists"));
 builder.Services.AddScoped(sp => new MongoDBRepository<DecisionNumbers>(cfg["MongoAPI"], cfg["MongoDBName"], "DecisionNumbers"));
+builder.Services.AddScoped(sp => new MongoDBRepository<SharedProcurementEntry>(cfg["MongoAPI"], cfg["MongoDBName"], "SharedProcurementEntries"));
+builder.Services.AddScoped(sp => new MongoDBRepository<UserNotification>(cfg["MongoAPI"], cfg["MongoDBName"], "UserNotifications"));
+builder.Services.AddScoped(sp => new MongoDBRepository<BackupUserNotification>(cfg["MongoAPI"], cfg["MongoBackupDBName"], "BackupUserNotifications"));
 
 builder.Services.AddSingleton<IMongoClient>(sp =>
     new MongoClient(cfg["MongoAPI"])
@@ -128,6 +131,9 @@ builder.Services.AddScoped<IAuthenticationService, AuthenticationService>();
 builder.Services.AddScoped<IInspectionAcceptanceNoteService, InspectionAcceptanceNoteService>();
 builder.Services.AddScoped<IUserOwnFeaturesListService, UserOwnFeaturesListService>();
 builder.Services.AddScoped<IDecisionNumbersService, DecisionNumbersService>();
+builder.Services.AddScoped<ISharedProcurementEntryService, SharedProcurementEntryService>();
+builder.Services.AddScoped<IUserNotificationService, UserNotificationService>();
+builder.Services.AddScoped<IBackupUserNotificationService, BackupUserNotificationService>();
 // Factoryler
 builder.Services.AddSingleton<ITeminApiExceptionFactory, TeminApiExceptionFactory>();
 

--- a/DogrudanTeminParadiseAPI/Service/Abstract/IBackupUserNotificationService.cs
+++ b/DogrudanTeminParadiseAPI/Service/Abstract/IBackupUserNotificationService.cs
@@ -1,0 +1,12 @@
+using DogrudanTeminParadiseAPI.Dto;
+
+namespace DogrudanTeminParadiseAPI.Service.Abstract
+{
+    public interface IBackupUserNotificationService
+    {
+        Task<BackupUserNotificationDto> CreateAsync(CreateBackupUserNotificationDto dto);
+        Task<IEnumerable<BackupUserNotificationDto>> GetAllAsync();
+        Task<BackupUserNotificationDto> GetByIdAsync(Guid id);
+        Task DeleteAsync(Guid id);
+    }
+}

--- a/DogrudanTeminParadiseAPI/Service/Abstract/ISharedProcurementEntryService.cs
+++ b/DogrudanTeminParadiseAPI/Service/Abstract/ISharedProcurementEntryService.cs
@@ -1,0 +1,10 @@
+using DogrudanTeminParadiseAPI.Dto;
+
+namespace DogrudanTeminParadiseAPI.Service.Abstract
+{
+    public interface ISharedProcurementEntryService
+    {
+        Task<SharedProcurementEntryDto> CreateAsync(CreateSharedProcurementEntryDto dto);
+        Task<IEnumerable<SharedProcurementEntryDto>> GetByUserAsync(Guid userId);
+    }
+}

--- a/DogrudanTeminParadiseAPI/Service/Abstract/IUserNotificationService.cs
+++ b/DogrudanTeminParadiseAPI/Service/Abstract/IUserNotificationService.cs
@@ -1,0 +1,12 @@
+using DogrudanTeminParadiseAPI.Dto;
+
+namespace DogrudanTeminParadiseAPI.Service.Abstract
+{
+    public interface IUserNotificationService
+    {
+        Task<UserNotificationDto> CreateAsync(CreateUserNotificationDto dto);
+        Task<IEnumerable<UserNotificationDto>> GetAsync(UserNotificationQueryDto query);
+        Task<UserNotificationDto> UpdateAsync(Guid id, UpdateUserNotificationDto dto);
+        Task DeleteAsync(Guid id, Guid userId);
+    }
+}

--- a/DogrudanTeminParadiseAPI/Service/Concrete/BackupUserNotificationService.cs
+++ b/DogrudanTeminParadiseAPI/Service/Concrete/BackupUserNotificationService.cs
@@ -1,0 +1,47 @@
+using AutoMapper;
+using DogrudanTeminParadiseAPI.Dto;
+using DogrudanTeminParadiseAPI.Models;
+using DogrudanTeminParadiseAPI.Repositories;
+using DogrudanTeminParadiseAPI.Service.Abstract;
+
+namespace DogrudanTeminParadiseAPI.Service.Concrete
+{
+    public class BackupUserNotificationService : IBackupUserNotificationService
+    {
+        private readonly MongoDBRepository<BackupUserNotification> _repo;
+        private readonly IMapper _mapper;
+
+        public BackupUserNotificationService(MongoDBRepository<BackupUserNotification> repo, IMapper mapper)
+        {
+            _repo = repo;
+            _mapper = mapper;
+        }
+
+        public async Task<BackupUserNotificationDto> CreateAsync(CreateBackupUserNotificationDto dto)
+        {
+            var entity = _mapper.Map<BackupUserNotification>(dto);
+            entity.Id = Guid.NewGuid();
+            await _repo.InsertAsync(entity);
+            return _mapper.Map<BackupUserNotificationDto>(entity);
+        }
+
+        public async Task<IEnumerable<BackupUserNotificationDto>> GetAllAsync()
+        {
+            var list = await _repo.GetAllAsync();
+            return list.Select(n => _mapper.Map<BackupUserNotificationDto>(n));
+        }
+
+        public async Task<BackupUserNotificationDto> GetByIdAsync(Guid id)
+        {
+            var e = await _repo.GetByIdAsync(id);
+            return e == null ? null : _mapper.Map<BackupUserNotificationDto>(e);
+        }
+
+        public async Task DeleteAsync(Guid id)
+        {
+            var existing = await _repo.GetByIdAsync(id);
+            if (existing == null) throw new KeyNotFoundException("Kayıt bulunamadı.");
+            await _repo.DeleteAsync(id);
+        }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Service/Concrete/SharedProcurementEntryService.cs
+++ b/DogrudanTeminParadiseAPI/Service/Concrete/SharedProcurementEntryService.cs
@@ -1,0 +1,37 @@
+using AutoMapper;
+using DogrudanTeminParadiseAPI.Dto;
+using DogrudanTeminParadiseAPI.Models;
+using DogrudanTeminParadiseAPI.Repositories;
+using DogrudanTeminParadiseAPI.Service.Abstract;
+
+namespace DogrudanTeminParadiseAPI.Service.Concrete
+{
+    public class SharedProcurementEntryService : ISharedProcurementEntryService
+    {
+        private readonly MongoDBRepository<SharedProcurementEntry> _repo;
+        private readonly IMapper _mapper;
+
+        public SharedProcurementEntryService(MongoDBRepository<SharedProcurementEntry> repo, IMapper mapper)
+        {
+            _repo = repo;
+            _mapper = mapper;
+        }
+
+        public async Task<SharedProcurementEntryDto> CreateAsync(CreateSharedProcurementEntryDto dto)
+        {
+            var entity = _mapper.Map<SharedProcurementEntry>(dto);
+            entity.Id = Guid.NewGuid();
+            entity.SharingDate = DateTime.UtcNow;
+            await _repo.InsertAsync(entity);
+            return _mapper.Map<SharedProcurementEntryDto>(entity);
+        }
+
+        public async Task<IEnumerable<SharedProcurementEntryDto>> GetByUserAsync(Guid userId)
+        {
+            var list = (await _repo.GetAllAsync())
+                .Where(x => x.ProcurementSharerUserId == userId || x.SharedToUserIds.Contains(userId));
+            return list.Select(x => _mapper.Map<SharedProcurementEntryDto>(x));
+        }
+
+    }
+}

--- a/DogrudanTeminParadiseAPI/Service/Concrete/UserNotificationService.cs
+++ b/DogrudanTeminParadiseAPI/Service/Concrete/UserNotificationService.cs
@@ -1,0 +1,70 @@
+using AutoMapper;
+using DogrudanTeminParadiseAPI.Dto;
+using DogrudanTeminParadiseAPI.Models;
+using DogrudanTeminParadiseAPI.Repositories;
+using DogrudanTeminParadiseAPI.Service.Abstract;
+
+namespace DogrudanTeminParadiseAPI.Service.Concrete
+{
+    public class UserNotificationService : IUserNotificationService
+    {
+        private readonly MongoDBRepository<UserNotification> _repo;
+        private readonly MongoDBRepository<BackupUserNotification> _backupRepo;
+        private readonly IMapper _mapper;
+
+        public UserNotificationService(
+            MongoDBRepository<UserNotification> repo,
+            MongoDBRepository<BackupUserNotification> backupRepo,
+            IMapper mapper)
+        {
+            _repo = repo;
+            _backupRepo = backupRepo;
+            _mapper = mapper;
+        }
+
+        public async Task<UserNotificationDto> CreateAsync(CreateUserNotificationDto dto)
+        {
+            var entity = _mapper.Map<UserNotification>(dto);
+            entity.Id = Guid.NewGuid();
+            entity.NotificationDate = DateTime.UtcNow;
+            await _repo.InsertAsync(entity);
+            return _mapper.Map<UserNotificationDto>(entity);
+        }
+
+        public async Task<IEnumerable<UserNotificationDto>> GetAsync(UserNotificationQueryDto query)
+        {
+            var list = await _repo.GetAllAsync();
+            if (query.FromDate.HasValue)
+                list = list.Where(n => n.NotificationDate >= query.FromDate.Value);
+            if (query.ToDate.HasValue)
+                list = list.Where(n => n.NotificationDate <= query.ToDate.Value);
+            if (query.ToUsers != null && query.ToUsers.Any())
+                list = list.Where(n => query.ToUsers.Contains(n.NotificationToUser));
+            if (!string.IsNullOrWhiteSpace(query.Header))
+                list = list.Where(n => (n.NotificationHeader ?? string.Empty).Contains(query.Header, StringComparison.OrdinalIgnoreCase));
+            list = list.OrderByDescending(n => n.NotificationDate).Take(query.Top);
+            return list.Select(n => _mapper.Map<UserNotificationDto>(n));
+        }
+
+        public async Task<UserNotificationDto> UpdateAsync(Guid id, UpdateUserNotificationDto dto)
+        {
+            var existing = await _repo.GetByIdAsync(id);
+            if (existing == null) throw new KeyNotFoundException("Bildirim bulunamadı.");
+            existing.IsMarkAsUnread = dto.IsMarkAsUnread;
+            await _repo.UpdateAsync(id, existing);
+            return _mapper.Map<UserNotificationDto>(existing);
+        }
+
+        public async Task DeleteAsync(Guid id, Guid userId)
+        {
+            var existing = await _repo.GetByIdAsync(id);
+            if (existing == null) throw new KeyNotFoundException("Bildirim bulunamadı.");
+            var backup = _mapper.Map<BackupUserNotification>(existing);
+            backup.Id = Guid.NewGuid();
+            backup.RemovedByUserId = userId;
+            backup.RemovingDate = DateTime.UtcNow;
+            await _backupRepo.InsertAsync(backup);
+            await _repo.DeleteAsync(id);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add backup model, DTOs, service and controller for user notifications
- save user notifications to backup on delete
- remove delete operation from shared procurement entries
- register new services and repositories in DI

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e5469c8c083238e49d81c3e1475f1