### PR TITLE
Implement getAllUserShareds endpoint

### DIFF
--- a/DogrudanTeminParadiseAPI/Controllers/ProcurementEntryController.cs
+++ b/DogrudanTeminParadiseAPI/Controllers/ProcurementEntryController.cs
@@ -159,5 +159,13 @@ namespace DogrudanTeminParadiseAPI.Controllers
             var isAdmin = User.IsInRole("ADMIN");
             return Ok(await _entrySvc.GetByRequesterAsync(userId, isAdmin));
         }
+
+        [HttpGet("get-all-user-shareds")]
+        public async Task<IActionResult> GetAllUserShareds()
+        {
+            var userId = Guid.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier));
+            var entries = await _entrySvc.GetAllUserSharedsAsync(userId);
+            return Ok(entries);
+        }
     }
 }

--- a/DogrudanTeminParadiseAPI/Service/Abstract/IProcurementEntryService.cs
+++ b/DogrudanTeminParadiseAPI/Service/Abstract/IProcurementEntryService.cs
@@ -19,5 +19,7 @@ namespace DogrudanTeminParadiseAPI.Service.Abstract
         Task<IEnumerable<ProcurementEntryDto>> GetByInspectionDateRangeAsync(ProcurementEntryDateRangeDto query);
         Task<IEnumerable<ProcurementEntryDto>> GetByRequesterAsync(Guid requesterId, bool isAdmin);
 
+        Task<IEnumerable<ProcurementEntryDto>> GetAllUserSharedsAsync(Guid userId);
+
     }
 }


### PR DESCRIPTION
## Summary
- support retrieving shared procurement entries
- add `GetAllUserSharedsAsync` in service layer
- expose new route `get-all-user-shareds` in `ProcurementEntryController`

## Testing
- `dotnet build DogrudanTeminParadiseAPI.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687012b4286c83238d2ff61e110c0fe5