### PR TITLE
Add endpoints for shared procurement entries

### DIFF
--- a/DogrudanTeminParadiseAPI/Controllers/SharedProcurementEntryController.cs
+++ b/DogrudanTeminParadiseAPI/Controllers/SharedProcurementEntryController.cs
@@ -28,5 +28,33 @@ namespace DogrudanTeminParadiseAPI.Controllers
             var list = await _svc.GetByUserAsync(userId, entryId);
             return Ok(list);
         }
+
+        [HttpDelete("procurement/{procurementId}/user/{userId}")]
+        public async Task<IActionResult> DeleteUserFromSharers(Guid procurementId, Guid userId)
+        {
+            try
+            {
+                await _svc.DeleteUserFromSharersAsync(procurementId, userId);
+                return NoContent();
+            }
+            catch (KeyNotFoundException ex)
+            {
+                return NotFound(new { error = ex.Message });
+            }
+        }
+
+        [HttpPut("procurement/{procurementId}")]
+        public async Task<IActionResult> UpdateSharedToIds(Guid procurementId, [FromBody] UpdateSharedToUserIdsDto dto)
+        {
+            try
+            {
+                var updated = await _svc.UpdateSharedToIdsAsync(procurementId, dto.SharedToUserIds);
+                return Ok(updated);
+            }
+            catch (KeyNotFoundException ex)
+            {
+                return NotFound(new { error = ex.Message });
+            }
+        }
     }
 }

--- a/DogrudanTeminParadiseAPI/Dto/UpdateSharedToUserIdsDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/UpdateSharedToUserIdsDto.cs
@@ -1,0 +1,7 @@
+namespace DogrudanTeminParadiseAPI.Dto
+{
+    public class UpdateSharedToUserIdsDto
+    {
+        public List<Guid> SharedToUserIds { get; set; } = new();
+    }
+}

--- a/DogrudanTeminParadiseAPI/Mapping/MappingProfile.cs
+++ b/DogrudanTeminParadiseAPI/Mapping/MappingProfile.cs
@@ -166,6 +166,7 @@ namespace DogrudanTeminParadiseAPI.Mapping
             CreateMap<DecisionNumbers, DecisionNumbersDto>();
 
             CreateMap<CreateSharedProcurementEntryDto, SharedProcurementEntry>();
+            CreateMap<UpdateSharedToUserIdsDto, SharedProcurementEntry>();
             CreateMap<SharedProcurementEntry, SharedProcurementEntryDto>();
 
             CreateMap<CreateUserNotificationDto, UserNotification>();

--- a/DogrudanTeminParadiseAPI/Service/Abstract/ISharedProcurementEntryService.cs
+++ b/DogrudanTeminParadiseAPI/Service/Abstract/ISharedProcurementEntryService.cs
@@ -6,5 +6,7 @@ namespace DogrudanTeminParadiseAPI.Service.Abstract
     {
         Task<SharedProcurementEntryDto> CreateAsync(CreateSharedProcurementEntryDto dto);
         Task<SharedProcurementEntryDto> GetByUserAsync(Guid userId, Guid procurementEntryId);
+        Task DeleteUserFromSharersAsync(Guid procurementId, Guid userId);
+        Task<SharedProcurementEntryDto> UpdateSharedToIdsAsync(Guid procurementId, List<Guid> sharedToUserIds);
     }
 }

--- a/DogrudanTeminParadiseAPI/Service/Concrete/SharedProcurementEntryService.cs
+++ b/DogrudanTeminParadiseAPI/Service/Concrete/SharedProcurementEntryService.cs
@@ -32,5 +32,31 @@ namespace DogrudanTeminParadiseAPI.Service.Concrete
                 .FirstOrDefault(x => x.ProcurementSharerUserId == userId && x.ProcurementId == procurementEntryId);
             return _mapper.Map<SharedProcurementEntryDto>(shared);
         }
+
+        public async Task DeleteUserFromSharersAsync(Guid procurementId, Guid userId)
+        {
+            var shared = (await _repo.GetAllAsync())
+                .FirstOrDefault(x => x.ProcurementId == procurementId && x.SharedToUserIds.Contains(userId));
+
+            if (shared == null)
+                throw new KeyNotFoundException("Paylaşım bulunamadı.");
+
+            shared.SharedToUserIds.Remove(userId);
+            await _repo.UpdateAsync(shared.Id, shared);
+        }
+
+        public async Task<SharedProcurementEntryDto> UpdateSharedToIdsAsync(Guid procurementId, List<Guid> sharedToUserIds)
+        {
+            var shared = (await _repo.GetAllAsync())
+                .FirstOrDefault(x => x.ProcurementId == procurementId);
+
+            if (shared == null)
+                throw new KeyNotFoundException("Paylaşım bulunamadı.");
+
+            shared.SharedToUserIds = sharedToUserIds ?? new();
+            await _repo.UpdateAsync(shared.Id, shared);
+
+            return _mapper.Map<SharedProcurementEntryDto>(shared);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add `UpdateSharedToUserIdsDto`
- extend shared procurement entry service interface
- implement delete/update logic in service
- update API mapping profile
- expose new update and delete endpoints in controller

## Testing
- `dotnet build DogrudanTeminParadiseAPI.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870311d5950832382a629c21672cbc1