### PR TITLE
Support admin scoped report queries

### DIFF
--- a/DogrudanTeminParadiseAPI/Service/Abstract/IReportService.cs
+++ b/DogrudanTeminParadiseAPI/Service/Abstract/IReportService.cs
@@ -11,11 +11,11 @@ namespace DogrudanTeminParadiseAPI.Service.Abstract
         Task<InspectionPriceStatsDto> GetInspectionPriceSumAsync(int days);
         Task<List<ProductPriceStatDto>> GetTopInspectionProductsAsync(int days, int top);
         Task<List<FirmStatDto>> GetTopInspectionFirmsMonthlyAsync(int top);
-        Task<List<LastJobsDto>> GetLast10JobsAsync(Guid tenderResponsibleId);
-        Task<List<TopUnitDto>> GetTopAdministrationUnitsAsync(Guid tenderResponsibleId);
-        Task<List<TopUnitDto>> GetTopSubAdministrationUnitsAsync(Guid tenderResponsibleId);
-        Task<List<TopUnitDto>> GetTopThreeSubAdministrationUnitsAsync(Guid tenderResponsibleId);
-        Task<SpendingReportDto> GetSpendingReportAsync(Guid tenderResponsibleId);
+        Task<List<LastJobsDto>> GetLast10JobsAsync(IEnumerable<Guid> tenderResponsibleIds);
+        Task<List<TopUnitDto>> GetTopAdministrationUnitsAsync(IEnumerable<Guid> tenderResponsibleIds);
+        Task<List<TopUnitDto>> GetTopSubAdministrationUnitsAsync(IEnumerable<Guid> tenderResponsibleIds);
+        Task<List<TopUnitDto>> GetTopThreeSubAdministrationUnitsAsync(IEnumerable<Guid> tenderResponsibleIds);
+        Task<SpendingReportDto> GetSpendingReportAsync(IEnumerable<Guid> tenderResponsibleIds);
         Task<SpendingByFirmDto> GetTopFirmsSpendingAsync(string periodType);
         Task<IEnumerable<UserCountDto>> GetTopResponsibleUsersAsync(int top = 3);
         Task<IEnumerable<UserCountDto>> GetBottomResponsibleUsersAsync(int bottom = 3);

--- a/DogrudanTeminParadiseAPI/Service/Concrete/ReportService.cs
+++ b/DogrudanTeminParadiseAPI/Service/Concrete/ReportService.cs
@@ -351,11 +351,12 @@ namespace DogrudanTeminParadiseAPI.Service.Concrete
             return result;
         }
 
-        public async Task<List<LastJobsDto>> GetLast10JobsAsync(Guid tenderResponsibleId)
+        public async Task<List<LastJobsDto>> GetLast10JobsAsync(IEnumerable<Guid> tenderResponsibleIds)
         {
+            var idSet = tenderResponsibleIds?.ToHashSet() ?? new HashSet<Guid>();
             var allEntries = await _entryRepo.GetAllAsync();
             var userEntries = allEntries
-                .Where(e => e.TenderResponsibleUserId == tenderResponsibleId)
+                .Where(e => e.TenderResponsibleUserId.HasValue && idSet.Contains(e.TenderResponsibleUserId.Value))
                 .ToList();
 
             if (!userEntries.Any())
@@ -412,11 +413,12 @@ namespace DogrudanTeminParadiseAPI.Service.Concrete
                 .ToList();
         }
 
-        public async Task<List<TopUnitDto>> GetTopAdministrationUnitsAsync(Guid tenderResponsibleId)
+        public async Task<List<TopUnitDto>> GetTopAdministrationUnitsAsync(IEnumerable<Guid> tenderResponsibleIds)
         {
+            var idSet = tenderResponsibleIds?.ToHashSet() ?? new HashSet<Guid>();
             var allEntries = await _entryRepo.GetAllAsync();
             var userEntryIds = allEntries
-                .Where(e => e.TenderResponsibleUserId == tenderResponsibleId)
+                .Where(e => e.TenderResponsibleUserId.HasValue && idSet.Contains(e.TenderResponsibleUserId.Value))
                 .Select(e => e.Id)
                 .ToHashSet();
 
@@ -468,11 +470,12 @@ namespace DogrudanTeminParadiseAPI.Service.Concrete
             return result;
         }
 
-        public async Task<List<TopUnitDto>> GetTopSubAdministrationUnitsAsync(Guid tenderResponsibleId)
+        public async Task<List<TopUnitDto>> GetTopSubAdministrationUnitsAsync(IEnumerable<Guid> tenderResponsibleIds)
         {
+            var idSet = tenderResponsibleIds?.ToHashSet() ?? new HashSet<Guid>();
             var allEntries = await _entryRepo.GetAllAsync();
             var userEntryIds = allEntries
-                .Where(e => e.TenderResponsibleUserId == tenderResponsibleId)
+                .Where(e => e.TenderResponsibleUserId.HasValue && idSet.Contains(e.TenderResponsibleUserId.Value))
                 .Select(e => e.Id)
                 .ToHashSet();
 
@@ -523,11 +526,12 @@ namespace DogrudanTeminParadiseAPI.Service.Concrete
             return result;
         }
 
-        public async Task<List<TopUnitDto>> GetTopThreeSubAdministrationUnitsAsync(Guid tenderResponsibleId)
+        public async Task<List<TopUnitDto>> GetTopThreeSubAdministrationUnitsAsync(IEnumerable<Guid> tenderResponsibleIds)
         {
+            var idSet = tenderResponsibleIds?.ToHashSet() ?? new HashSet<Guid>();
             var allEntries = await _entryRepo.GetAllAsync();
             var userEntryIds = allEntries
-                .Where(e => e.TenderResponsibleUserId == tenderResponsibleId)
+                .Where(e => e.TenderResponsibleUserId.HasValue && idSet.Contains(e.TenderResponsibleUserId.Value))
                 .Select(e => e.Id)
                 .ToHashSet();
 
@@ -578,11 +582,12 @@ namespace DogrudanTeminParadiseAPI.Service.Concrete
             return result;
         }
 
-        public async Task<SpendingReportDto> GetSpendingReportAsync(Guid tenderResponsibleId)
+        public async Task<SpendingReportDto> GetSpendingReportAsync(IEnumerable<Guid> tenderResponsibleIds)
         {
+            var idSet = tenderResponsibleIds?.ToHashSet() ?? new HashSet<Guid>();
             var allEntries = await _entryRepo.GetAllAsync();
             var userEntries = allEntries
-                .Where(e => e.TenderResponsibleUserId == tenderResponsibleId)
+                .Where(e => e.TenderResponsibleUserId.HasValue && idSet.Contains(e.TenderResponsibleUserId.Value))
                 .ToList();
 
             if (!userEntries.Any())


### PR DESCRIPTION
## Summary
- extend report service methods to accept multiple responsible user ids
- include super admin service in report controller to gather subordinate user ids
- add helper to resolve responsible ids when special Guid is provided
- adjust report endpoints to use new service signatures

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687398000af8832392383d57ce82e2c1