### PR TITLE
Add DeleteAll endpoint for notifications

### DIFF
--- a/DogrudanTeminParadiseAPI/Controllers/NotificationController.cs
+++ b/DogrudanTeminParadiseAPI/Controllers/NotificationController.cs
@@ -36,6 +36,20 @@ namespace DogrudanTeminParadiseAPI.Controllers
             return Ok(list);
         }
 
+        [HttpDelete("user/{userId}")]
+        public async Task<IActionResult> DeleteAll(Guid userId)
+        {
+            await _svc.DeleteAllAsync(userId);
+            return NoContent();
+        }
+
+        [HttpPut("user/{userId}/markAllIsRead")]
+        public async Task<IActionResult> MarkAllIsRead(Guid userId)
+        {
+            await _svc.MarkAllIsReadAsync(userId);
+            return NoContent();
+        }
+
         [HttpGet("{id}")]
         public async Task<IActionResult> GetById(Guid id)
         {

--- a/DogrudanTeminParadiseAPI/Service/Abstract/INotificationService.cs
+++ b/DogrudanTeminParadiseAPI/Service/Abstract/INotificationService.cs
@@ -10,5 +10,7 @@ namespace DogrudanTeminParadiseAPI.Service.Abstract
         Task<IEnumerable<NotificationDto>> GetAllAsync();
         Task<IEnumerable<NotificationDto>> GetAllByUserIdAsync(Guid userId);
         Task<NotificationDto> MarkIsReadAsync(Guid id);
+        Task DeleteAllAsync(Guid userId);
+        Task MarkAllIsReadAsync(Guid userId);
     }
 }

--- a/DogrudanTeminParadiseAPI/Service/Concrete/NotificationService.cs
+++ b/DogrudanTeminParadiseAPI/Service/Concrete/NotificationService.cs
@@ -3,6 +3,7 @@ using DogrudanTeminParadiseAPI.Dto;
 using DogrudanTeminParadiseAPI.Models;
 using DogrudanTeminParadiseAPI.Repositories;
 using DogrudanTeminParadiseAPI.Service.Abstract;
+using MongoDB.Driver;
 
 namespace DogrudanTeminParadiseAPI.Service.Concrete
 {
@@ -32,6 +33,27 @@ namespace DogrudanTeminParadiseAPI.Service.Concrete
             if (existing == null)
                 throw new KeyNotFoundException("Bildirim bulunamadı.");
             await _repo.DeleteAsync(id);
+        }
+
+        public async Task DeleteAllAsync(Guid userId)
+        {
+            var filter = Builders<Notification>.Filter.Eq(n => n.UserId, userId);
+            var list = await _repo.GetAllAsync(filter);
+            foreach (var item in list)
+            {
+                await _repo.DeleteAsync(item.Id);
+            }
+        }
+
+        public async Task MarkAllIsReadAsync(Guid userId)
+        {
+            var filter = Builders<Notification>.Filter.Eq(n => n.UserId, userId);
+            var list = await _repo.GetAllAsync(filter);
+            foreach (var item in list)
+            {
+                item.IsRead = true;
+                await _repo.UpdateAsync(item.Id, item);
+            }
         }
 
         public async Task<IEnumerable<NotificationDto>> GetAllAsync()


### PR DESCRIPTION
## Summary
- add DeleteAllAsync method to NotificationService and interface
- expose DELETE `user/{userId}` endpoint in NotificationController
- add ReadAll logic and endpoint to mark all notifications for a user as read

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cecf4371c8323acf8ed2ca1878a49