### PR TITLE
Change quantity type to double

### DIFF
--- a/DogrudanTeminParadiseAPI/Dto/CreateOfferItemDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/CreateOfferItemDto.cs
@@ -6,7 +6,7 @@ namespace DogrudanTeminParadiseAPI.Dto
     {
         public string Name { get; set; }
         public List<Feature> Features { get; set; } = new();
-        public int Quantity { get; set; }
+        public double Quantity { get; set; }
         public Guid UnitId { get; set; }
         public double UnitPrice { get; set; }
     }

--- a/DogrudanTeminParadiseAPI/Dto/CreateProcurementListItemDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/CreateProcurementListItemDto.cs
@@ -4,7 +4,7 @@
     {
         public Guid ProcurementEntryId { get; set; }
         public string Name { get; set; }
-        public int Quantity { get; set; }
+        public double Quantity { get; set; }
         public Guid UnitId { get; set; }
     }
 }

--- a/DogrudanTeminParadiseAPI/Dto/InspectionAcceptanceReportDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/InspectionAcceptanceReportDto.cs
@@ -15,7 +15,7 @@
     public class InspectionItemDto
     {
         public string Name { get; set; }
-        public int Quantity { get; set; }
+        public double Quantity { get; set; }
         public string UnitName { get; set; }
     }
 }

--- a/DogrudanTeminParadiseAPI/Dto/ItemCostDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/ItemCostDto.cs
@@ -3,7 +3,7 @@
     public class ItemCostDto
     {
         public string ItemName { get; set; }
-        public int Quantity { get; set; }
+        public double Quantity { get; set; }
         public string UnitName { get; set; }
         public List<BidDto> Bids { get; set; }
         public double AverageUnitPrice { get; set; }

--- a/DogrudanTeminParadiseAPI/Dto/OfferItemDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/OfferItemDto.cs
@@ -7,7 +7,7 @@ namespace DogrudanTeminParadiseAPI.Dto
         public Guid Id { get; set; }
         public string Name { get; set; }
         public List<Feature> Features { get; set; }
-        public int Quantity { get; set; }
+        public double Quantity { get; set; }
         public Guid UnitId { get; set; }
         public double UnitPrice { get; set; }
         public double TotalAmount { get; set; }

--- a/DogrudanTeminParadiseAPI/Dto/ProcurementListItemDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/ProcurementListItemDto.cs
@@ -5,7 +5,7 @@
         public Guid Id { get; set; }
         public Guid ProcurementEntryId { get; set; }
         public string Name { get; set; }
-        public int Quantity { get; set; }
+        public double Quantity { get; set; }
         public Guid UnitId { get; set; }
     }
 }

--- a/DogrudanTeminParadiseAPI/Dto/UpdateOfferItemDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/UpdateOfferItemDto.cs
@@ -6,7 +6,7 @@ namespace DogrudanTeminParadiseAPI.Dto
     {
         public string Name { get; set; }
         public List<Feature> Features { get; set; } = new();
-        public int Quantity { get; set; }
+        public double Quantity { get; set; }
         public Guid UnitId { get; set; }
         public double UnitPrice { get; set; }
     }

--- a/DogrudanTeminParadiseAPI/Helpers/HelperClasses.cs
+++ b/DogrudanTeminParadiseAPI/Helpers/HelperClasses.cs
@@ -55,7 +55,7 @@ namespace DogrudanTeminParadiseAPI.Helpers
 
         public string Name { get; set; }
         public List<Feature> Features { get; set; } = new();
-        public int Quantity { get; set; }
+        public double Quantity { get; set; }
 
         [BsonRepresentation(BsonType.String)]
         public Guid UnitId { get; set; }

--- a/DogrudanTeminParadiseAPI/Models/OfferItem.cs
+++ b/DogrudanTeminParadiseAPI/Models/OfferItem.cs
@@ -12,7 +12,7 @@ namespace DogrudanTeminParadiseAPI.Models
 
         public string Name { get; set; }
         public List<Feature> Features { get; set; } = new();
-        public int Quantity { get; set; }
+        public double Quantity { get; set; }
 
         [BsonRepresentation(BsonType.String)]
         public Guid UnitId { get; set; }

--- a/DogrudanTeminParadiseAPI/Models/ProcurementListItem.cs
+++ b/DogrudanTeminParadiseAPI/Models/ProcurementListItem.cs
@@ -14,7 +14,7 @@ namespace DogrudanTeminParadiseAPI.Models
         public Guid ProcurementEntryId { get; set; }
 
         public string Name { get; set; }
-        public int Quantity { get; set; }
+        public double Quantity { get; set; }
 
         [BsonRepresentation(BsonType.String)]
         public Guid UnitId { get; set; }

--- a/DogrudanTeminParadiseAPI/Service/Concrete/OfferLetterService.cs
+++ b/DogrudanTeminParadiseAPI/Service/Concrete/OfferLetterService.cs
@@ -142,7 +142,7 @@ namespace DogrudanTeminParadiseAPI.Service.Concrete
                 {
                     if (qtyMap.TryGetValue(item.Id, out var newQty))
                     {
-                        item.Quantity = (int)newQty;
+                        item.Quantity = newQty;
                         updated = true;
                     }
                 }


### PR DESCRIPTION
## Summary
- update Quantity properties in DTOs and models from `int` to `double`
- adjust OfferLetterService to remove cast

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e82bb01a88323ab162be8cfba37a5