### PR TITLE
Add ReportAdministration reporting module

### DIFF
--- a/DogrudanTeminParadiseAPI/Controllers/ReportAdministrationController.cs
+++ b/DogrudanTeminParadiseAPI/Controllers/ReportAdministrationController.cs
@@ -1,0 +1,121 @@
+using DogrudanTeminParadiseAPI.Dto;
+using DogrudanTeminParadiseAPI.Helpers.Attributes;
+using DogrudanTeminParadiseAPI.Parameters;
+using DogrudanTeminParadiseAPI.Service.Abstract;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+
+namespace DogrudanTeminParadiseAPI.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    [Authorize]
+    [CallLogs]
+    public class ReportAdministrationController : ControllerBase
+    {
+        private readonly IReportAdministrationService _svc;
+        private readonly ISuperAdminService _superAdminSvc;
+
+        public ReportAdministrationController(IReportAdministrationService svc, ISuperAdminService superAdminSvc)
+        {
+            _svc = svc;
+            _superAdminSvc = superAdminSvc;
+        }
+
+        [HttpGet("most-entry-sub")]
+        public async Task<IActionResult> GetMostEntrySub([FromQuery] Guid tenderResponsibleId, [FromQuery] int top = 3)
+        {
+            var ids = await ResolveTenderResponsibleIds(tenderResponsibleId);
+            var data = await _svc.GetMostEntrySubAdministrationUnitsAsync(ids, top);
+            return Ok(data);
+        }
+
+        [HttpGet("least-entry-sub")]
+        public async Task<IActionResult> GetLeastEntrySub([FromQuery] Guid tenderResponsibleId, [FromQuery] int top = 3)
+        {
+            var ids = await ResolveTenderResponsibleIds(tenderResponsibleId);
+            var data = await _svc.GetLeastEntrySubAdministrationUnitsAsync(ids, top);
+            return Ok(data);
+        }
+
+        [HttpGet("avg-price-sub")]
+        public async Task<IActionResult> GetAvgPriceSub([FromQuery] string periodType = "yearly")
+        {
+            var data = await _svc.GetSubAdministrationAveragePricesAsync(periodType);
+            return Ok(data);
+        }
+
+        [HttpGet("avg-price-three-sub")]
+        public async Task<IActionResult> GetAvgPriceThreeSub([FromQuery] string periodType = "yearly")
+        {
+            var data = await _svc.GetThreeSubAdministrationAveragePricesAsync(periodType);
+            return Ok(data);
+        }
+
+        [HttpGet("certificate-count-sub")]
+        public async Task<IActionResult> GetCertificateCountSub()
+        {
+            var data = await _svc.GetSubAdministrationCertificateCountsAsync();
+            return Ok(data);
+        }
+
+        [HttpGet("certificate-count-three-sub")]
+        public async Task<IActionResult> GetCertificateCountThreeSub()
+        {
+            var data = await _svc.GetThreeSubAdministrationCertificateCountsAsync();
+            return Ok(data);
+        }
+
+        [HttpGet("offer-count-sub")]
+        public async Task<IActionResult> GetOfferCountSub()
+        {
+            var data = await _svc.GetSubAdministrationOfferCountsAsync();
+            return Ok(data);
+        }
+
+        [HttpGet("offer-count-three-sub")]
+        public async Task<IActionResult> GetOfferCountThreeSub()
+        {
+            var data = await _svc.GetThreeSubAdministrationOfferCountsAsync();
+            return Ok(data);
+        }
+
+        [HttpGet("offer-total-sub")]
+        public async Task<IActionResult> GetOfferTotalSub()
+        {
+            var data = await _svc.GetSubAdministrationOfferTotalsAsync();
+            return Ok(data);
+        }
+
+        [HttpGet("offer-total-three-sub")]
+        public async Task<IActionResult> GetOfferTotalThreeSub()
+        {
+            var data = await _svc.GetThreeSubAdministrationOfferTotalsAsync();
+            return Ok(data);
+        }
+
+        private async Task<IEnumerable<Guid>> ResolveTenderResponsibleIds(Guid tenderResponsibleId)
+        {
+            var allGuid = Guid.Parse("ffffffff-ffff-ffff-ffff-ffffffffffff");
+            if (tenderResponsibleId != allGuid)
+                return new List<Guid> { tenderResponsibleId };
+
+            var userIdClaim = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (!Guid.TryParse(userIdClaim, out var adminId))
+                throw new UnauthorizedAccessException();
+
+            List<Guid> list;
+            try
+            {
+                list = await _superAdminSvc.GetAdminPermissionsAsync(adminId);
+            }
+            catch
+            {
+                list = new List<Guid>();
+            }
+            list.Insert(0, adminId);
+            return list;
+        }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Dto/UnitPriceStatDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/UnitPriceStatDto.cs
@@ -1,0 +1,8 @@
+namespace DogrudanTeminParadiseAPI.Dto
+{
+    public class UnitPriceStatDto
+    {
+        public string UnitName { get; set; }
+        public double Value { get; set; }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Program.cs
+++ b/DogrudanTeminParadiseAPI/Program.cs
@@ -114,6 +114,7 @@ builder.Services.AddScoped<IBackupOfferLetterService, BackupOfferLetterService>(
 builder.Services.AddScoped<IReportService, ReportService>();
 builder.Services.AddScoped<IReportBudgetItemService, ReportBudgetItemService>();
 builder.Services.AddScoped<IReportProductService, ReportProductService>();
+builder.Services.AddScoped<IReportAdministrationService, ReportAdministrationService>();
 builder.Services.AddScoped<ICategoryService, CategoryService>();
 builder.Services.AddScoped<IBudgetItemService, BudgetItemService>();
 builder.Services.AddScoped<IMarketResearchJuryService, MarketResearchJuryService>();

--- a/DogrudanTeminParadiseAPI/Service/Abstract/IReportAdministrationService.cs
+++ b/DogrudanTeminParadiseAPI/Service/Abstract/IReportAdministrationService.cs
@@ -1,0 +1,18 @@
+using DogrudanTeminParadiseAPI.Dto;
+
+namespace DogrudanTeminParadiseAPI.Service.Abstract
+{
+    public interface IReportAdministrationService
+    {
+        Task<IEnumerable<TopUnitDto>> GetMostEntrySubAdministrationUnitsAsync(IEnumerable<Guid> userIds, int top = 3);
+        Task<IEnumerable<TopUnitDto>> GetLeastEntrySubAdministrationUnitsAsync(IEnumerable<Guid> userIds, int top = 3);
+        Task<IEnumerable<UnitPriceStatDto>> GetSubAdministrationAveragePricesAsync(string periodType);
+        Task<IEnumerable<UnitPriceStatDto>> GetThreeSubAdministrationAveragePricesAsync(string periodType);
+        Task<IEnumerable<TopUnitDto>> GetSubAdministrationCertificateCountsAsync();
+        Task<IEnumerable<TopUnitDto>> GetThreeSubAdministrationCertificateCountsAsync();
+        Task<IEnumerable<TopUnitDto>> GetSubAdministrationOfferCountsAsync();
+        Task<IEnumerable<TopUnitDto>> GetThreeSubAdministrationOfferCountsAsync();
+        Task<IEnumerable<UnitPriceStatDto>> GetSubAdministrationOfferTotalsAsync();
+        Task<IEnumerable<UnitPriceStatDto>> GetThreeSubAdministrationOfferTotalsAsync();
+    }
+}

--- a/DogrudanTeminParadiseAPI/Service/Concrete/ReportAdministrationService.cs
+++ b/DogrudanTeminParadiseAPI/Service/Concrete/ReportAdministrationService.cs
@@ -1,0 +1,298 @@
+using DogrudanTeminParadiseAPI.Dto;
+using DogrudanTeminParadiseAPI.Models;
+using DogrudanTeminParadiseAPI.Repositories;
+using DogrudanTeminParadiseAPI.Service.Abstract;
+
+namespace DogrudanTeminParadiseAPI.Service.Concrete
+{
+    public class ReportAdministrationService : IReportAdministrationService
+    {
+        private readonly MongoDBRepository<ProcurementEntry> _entryRepo;
+        private readonly MongoDBRepository<InspectionAcceptanceCertificate> _inspectionRepo;
+        private readonly MongoDBRepository<AdditionalInspectionAcceptanceCertificate> _addInspectionRepo;
+        private readonly MongoDBRepository<OfferLetter> _offerRepo;
+        private readonly MongoDBRepository<SubAdministrationUnit> _subRepo;
+        private readonly MongoDBRepository<ThreeSubAdministrationUnit> _threeSubRepo;
+
+        public ReportAdministrationService(
+            MongoDBRepository<ProcurementEntry> entryRepo,
+            MongoDBRepository<InspectionAcceptanceCertificate> inspectionRepo,
+            MongoDBRepository<AdditionalInspectionAcceptanceCertificate> addInspectionRepo,
+            MongoDBRepository<OfferLetter> offerRepo,
+            MongoDBRepository<SubAdministrationUnit> subRepo,
+            MongoDBRepository<ThreeSubAdministrationUnit> threeSubRepo)
+        {
+            _entryRepo = entryRepo;
+            _inspectionRepo = inspectionRepo;
+            _addInspectionRepo = addInspectionRepo;
+            _offerRepo = offerRepo;
+            _subRepo = subRepo;
+            _threeSubRepo = threeSubRepo;
+        }
+
+        private static double SumCertificate(InspectionAcceptanceCertificate cert)
+        {
+            return cert.SelectedProducts.Sum(p => p.UnitPrice * p.Quantity);
+        }
+
+        private static double SumCertificate(AdditionalInspectionAcceptanceCertificate cert)
+        {
+            return cert.SelectedProducts.Sum(p => p.UnitPrice * p.Quantity);
+        }
+
+        public async Task<IEnumerable<TopUnitDto>> GetMostEntrySubAdministrationUnitsAsync(IEnumerable<Guid> userIds, int top = 3)
+        {
+            var idSet = userIds?.ToHashSet() ?? new HashSet<Guid>();
+            var entries = (await _entryRepo.GetAllAsync())
+                .Where(e => e.SubAdministrationUnitId.HasValue &&
+                            (!idSet.Any() || (e.TenderResponsibleUserId.HasValue && idSet.Contains(e.TenderResponsibleUserId.Value))))
+                .ToList();
+
+            var counts = entries
+                .GroupBy(e => e.SubAdministrationUnitId!.Value)
+                .Select(g => new { Id = g.Key, Count = g.Count() })
+                .OrderByDescending(x => x.Count)
+                .ToList();
+
+            var topList = counts.Take(top).ToList();
+            var other = counts.Skip(top).Sum(x => x.Count);
+            var subs = (await _subRepo.GetAllAsync()).ToDictionary(s => s.Id, s => s.Code);
+            var result = new List<TopUnitDto>();
+            foreach (var item in topList)
+            {
+                var name = subs.TryGetValue(item.Id, out var code) ? code : "Bilinmeyen";
+                result.Add(new TopUnitDto { UnitName = name, Count = item.Count });
+            }
+            if (other > 0)
+                result.Add(new TopUnitDto { UnitName = "Diğer", Count = other });
+            return result;
+        }
+
+        public async Task<IEnumerable<TopUnitDto>> GetLeastEntrySubAdministrationUnitsAsync(IEnumerable<Guid> userIds, int top = 3)
+        {
+            var idSet = userIds?.ToHashSet() ?? new HashSet<Guid>();
+            var entries = (await _entryRepo.GetAllAsync())
+                .Where(e => e.SubAdministrationUnitId.HasValue &&
+                            (!idSet.Any() || (e.TenderResponsibleUserId.HasValue && idSet.Contains(e.TenderResponsibleUserId.Value))))
+                .ToList();
+
+            var counts = entries
+                .GroupBy(e => e.SubAdministrationUnitId!.Value)
+                .Select(g => new { Id = g.Key, Count = g.Count() })
+                .OrderBy(x => x.Count)
+                .ToList();
+
+            var topList = counts.Take(top).ToList();
+            var other = counts.Skip(top).Sum(x => x.Count);
+            var subs = (await _subRepo.GetAllAsync()).ToDictionary(s => s.Id, s => s.Code);
+            var result = new List<TopUnitDto>();
+            foreach (var item in topList)
+            {
+                var name = subs.TryGetValue(item.Id, out var code) ? code : "Bilinmeyen";
+                result.Add(new TopUnitDto { UnitName = name, Count = item.Count });
+            }
+            if (other > 0)
+                result.Add(new TopUnitDto { UnitName = "Diğer", Count = other });
+            return result;
+        }
+
+        private static int PeriodDays(string periodType)
+        {
+            return periodType?.ToLowerInvariant() switch
+            {
+                "weekly" => 7,
+                "monthly" => 30,
+                "quarterly" => 90,
+                _ => 365,
+            };
+        }
+
+        public async Task<IEnumerable<UnitPriceStatDto>> GetSubAdministrationAveragePricesAsync(string periodType)
+        {
+            var days = PeriodDays(periodType);
+            var end = DateTime.UtcNow.Date;
+            var start = end.AddDays(-days + 1);
+
+            var normals = (await _inspectionRepo.GetAllAsync())
+                .Where(c => c.InvoiceDate.Date >= start && c.InvoiceDate.Date <= end)
+                .Select(c => new { c.SubAdministrationUnitId, Total = SumCertificate(c) });
+            var additionals = (await _addInspectionRepo.GetAllAsync())
+                .Where(c => c.InvoiceDate.Date >= start && c.InvoiceDate.Date <= end)
+                .Select(c => new { c.SubAdministrationUnitId, Total = SumCertificate(c) });
+
+            var records = normals.Concat(additionals).ToList();
+            if (!records.Any())
+                return new List<UnitPriceStatDto>();
+
+            var groups = records
+                .GroupBy(r => r.SubAdministrationUnitId)
+                .Select(g => new { Id = g.Key, Avg = g.Average(x => x.Total) })
+                .OrderByDescending(x => x.Avg)
+                .ToList();
+
+            var subs = (await _subRepo.GetAllAsync()).ToDictionary(s => s.Id, s => s.Code);
+            return groups.Select(g => new UnitPriceStatDto
+            {
+                UnitName = subs.TryGetValue(g.Id, out var code) ? code : "Bilinmeyen",
+                Value = g.Avg
+            }).ToList();
+        }
+
+        public async Task<IEnumerable<UnitPriceStatDto>> GetThreeSubAdministrationAveragePricesAsync(string periodType)
+        {
+            var days = PeriodDays(periodType);
+            var end = DateTime.UtcNow.Date;
+            var start = end.AddDays(-days + 1);
+
+            var normals = (await _inspectionRepo.GetAllAsync())
+                .Where(c => c.InvoiceDate.Date >= start && c.InvoiceDate.Date <= end)
+                .Select(c => new { c.ThreeSubAdministrationUnitId, Total = SumCertificate(c) });
+            var additionals = (await _addInspectionRepo.GetAllAsync())
+                .Where(c => c.InvoiceDate.Date >= start && c.InvoiceDate.Date <= end)
+                .Select(c => new { c.ThreeSubAdministrationUnitId, Total = SumCertificate(c) });
+
+            var records = normals.Concat(additionals).ToList();
+            if (!records.Any())
+                return new List<UnitPriceStatDto>();
+
+            var groups = records
+                .GroupBy(r => r.ThreeSubAdministrationUnitId)
+                .Select(g => new { Id = g.Key, Avg = g.Average(x => x.Total) })
+                .OrderByDescending(x => x.Avg)
+                .ToList();
+
+            var units = (await _threeSubRepo.GetAllAsync()).ToDictionary(s => s.Id, s => s.Code);
+            return groups.Select(g => new UnitPriceStatDto
+            {
+                UnitName = units.TryGetValue(g.Id, out var code) ? code : "Bilinmeyen",
+                Value = g.Avg
+            }).ToList();
+        }
+
+        public async Task<IEnumerable<TopUnitDto>> GetSubAdministrationCertificateCountsAsync()
+        {
+            var normals = await _inspectionRepo.GetAllAsync();
+            var additionals = await _addInspectionRepo.GetAllAsync();
+            var records = normals
+                .Select(c => c.SubAdministrationUnitId)
+                .Concat(additionals.Select(c => c.SubAdministrationUnitId))
+                .GroupBy(id => id)
+                .Select(g => new { Id = g.Key, Count = g.Count() })
+                .OrderByDescending(x => x.Count)
+                .ToList();
+
+            var subs = (await _subRepo.GetAllAsync()).ToDictionary(s => s.Id, s => s.Code);
+            return records.Select(r => new TopUnitDto
+            {
+                UnitName = subs.TryGetValue(r.Id, out var code) ? code : "Bilinmeyen",
+                Count = r.Count
+            }).ToList();
+        }
+
+        public async Task<IEnumerable<TopUnitDto>> GetThreeSubAdministrationCertificateCountsAsync()
+        {
+            var normals = await _inspectionRepo.GetAllAsync();
+            var additionals = await _addInspectionRepo.GetAllAsync();
+            var records = normals
+                .Select(c => c.ThreeSubAdministrationUnitId)
+                .Concat(additionals.Select(c => c.ThreeSubAdministrationUnitId))
+                .GroupBy(id => id)
+                .Select(g => new { Id = g.Key, Count = g.Count() })
+                .OrderByDescending(x => x.Count)
+                .ToList();
+
+            var units = (await _threeSubRepo.GetAllAsync()).ToDictionary(s => s.Id, s => s.Code);
+            return records.Select(r => new TopUnitDto
+            {
+                UnitName = units.TryGetValue(r.Id, out var code) ? code : "Bilinmeyen",
+                Count = r.Count
+            }).ToList();
+        }
+
+        public async Task<IEnumerable<TopUnitDto>> GetSubAdministrationOfferCountsAsync()
+        {
+            var entries = await _entryRepo.GetAllAsync();
+            var subs = entries.Where(e => e.SubAdministrationUnitId.HasValue)
+                .ToDictionary(e => e.Id, e => e.SubAdministrationUnitId!.Value);
+
+            var offers = await _offerRepo.GetAllAsync();
+            var counts = offers
+                .Where(o => subs.ContainsKey(o.ProcurementEntryId))
+                .GroupBy(o => subs[o.ProcurementEntryId])
+                .Select(g => new { Id = g.Key, Count = g.Count() })
+                .OrderByDescending(x => x.Count)
+                .ToList();
+
+            var lookup = (await _subRepo.GetAllAsync()).ToDictionary(s => s.Id, s => s.Code);
+            return counts.Select(c => new TopUnitDto
+            {
+                UnitName = lookup.TryGetValue(c.Id, out var code) ? code : "Bilinmeyen",
+                Count = c.Count
+            }).ToList();
+        }
+
+        public async Task<IEnumerable<TopUnitDto>> GetThreeSubAdministrationOfferCountsAsync()
+        {
+            var entries = await _entryRepo.GetAllAsync();
+            var lookupEntry = entries.Where(e => e.ThreeSubAdministrationUnitId.HasValue)
+                .ToDictionary(e => e.Id, e => e.ThreeSubAdministrationUnitId!.Value);
+
+            var offers = await _offerRepo.GetAllAsync();
+            var counts = offers
+                .Where(o => lookupEntry.ContainsKey(o.ProcurementEntryId))
+                .GroupBy(o => lookupEntry[o.ProcurementEntryId])
+                .Select(g => new { Id = g.Key, Count = g.Count() })
+                .OrderByDescending(x => x.Count)
+                .ToList();
+
+            var units = (await _threeSubRepo.GetAllAsync()).ToDictionary(s => s.Id, s => s.Code);
+            return counts.Select(c => new TopUnitDto
+            {
+                UnitName = units.TryGetValue(c.Id, out var code) ? code : "Bilinmeyen",
+                Count = c.Count
+            }).ToList();
+        }
+
+        public async Task<IEnumerable<UnitPriceStatDto>> GetSubAdministrationOfferTotalsAsync()
+        {
+            var entries = await _entryRepo.GetAllAsync();
+            var subs = entries.Where(e => e.SubAdministrationUnitId.HasValue)
+                .ToDictionary(e => e.Id, e => e.SubAdministrationUnitId!.Value);
+            var offers = await _offerRepo.GetAllAsync();
+            var totals = offers
+                .Where(o => subs.ContainsKey(o.ProcurementEntryId))
+                .GroupBy(o => subs[o.ProcurementEntryId])
+                .Select(g => new { Id = g.Key, Total = g.Sum(o => o.OfferItems.Sum(i => i.TotalAmount)) })
+                .OrderByDescending(x => x.Total)
+                .ToList();
+
+            var lookup = (await _subRepo.GetAllAsync()).ToDictionary(s => s.Id, s => s.Code);
+            return totals.Select(t => new UnitPriceStatDto
+            {
+                UnitName = lookup.TryGetValue(t.Id, out var code) ? code : "Bilinmeyen",
+                Value = t.Total
+            }).ToList();
+        }
+
+        public async Task<IEnumerable<UnitPriceStatDto>> GetThreeSubAdministrationOfferTotalsAsync()
+        {
+            var entries = await _entryRepo.GetAllAsync();
+            var lookupEntry = entries.Where(e => e.ThreeSubAdministrationUnitId.HasValue)
+                .ToDictionary(e => e.Id, e => e.ThreeSubAdministrationUnitId!.Value);
+            var offers = await _offerRepo.GetAllAsync();
+            var totals = offers
+                .Where(o => lookupEntry.ContainsKey(o.ProcurementEntryId))
+                .GroupBy(o => lookupEntry[o.ProcurementEntryId])
+                .Select(g => new { Id = g.Key, Total = g.Sum(o => o.OfferItems.Sum(i => i.TotalAmount)) })
+                .OrderByDescending(x => x.Total)
+                .ToList();
+
+            var units = (await _threeSubRepo.GetAllAsync()).ToDictionary(s => s.Id, s => s.Code);
+            return totals.Select(t => new UnitPriceStatDto
+            {
+                UnitName = units.TryGetValue(t.Id, out var code) ? code : "Bilinmeyen",
+                Value = t.Total
+            }).ToList();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement new ReportAdministration module
- support average price and counts for sub administration units
- expose controller endpoints for new statistics
- register service in Program.cs

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f44f68e788323a7e3099a066aedb5