### PR TITLE
Implement delete method for SharedProcurementEntry

### DIFF
--- a/DogrudanTeminParadiseAPI/Controllers/SharedProcurementEntryController.cs
+++ b/DogrudanTeminParadiseAPI/Controllers/SharedProcurementEntryController.cs
@@ -56,5 +56,19 @@ namespace DogrudanTeminParadiseAPI.Controllers
                 return NotFound(new { error = ex.Message });
             }
         }
+
+        [HttpDelete("entry/{shareEntryId}")]
+        public async Task<IActionResult> Delete(Guid shareEntryId)
+        {
+            try
+            {
+                await _svc.DeleteAsync(shareEntryId);
+                return NoContent();
+            }
+            catch (KeyNotFoundException ex)
+            {
+                return NotFound(new { error = ex.Message });
+            }
+        }
     }
 }

--- a/DogrudanTeminParadiseAPI/Service/Abstract/ISharedProcurementEntryService.cs
+++ b/DogrudanTeminParadiseAPI/Service/Abstract/ISharedProcurementEntryService.cs
@@ -8,5 +8,6 @@ namespace DogrudanTeminParadiseAPI.Service.Abstract
         Task<SharedProcurementEntryDto> GetByUserAsync(Guid userId, Guid procurementEntryId);
         Task DeleteUserFromSharersAsync(Guid procurementId, Guid userId);
         Task<SharedProcurementEntryDto> UpdateSharedToIdsAsync(Guid procurementId, List<Guid> sharedToUserIds);
+        Task DeleteAsync(Guid id);
     }
 }

--- a/DogrudanTeminParadiseAPI/Service/Concrete/SharedProcurementEntryService.cs
+++ b/DogrudanTeminParadiseAPI/Service/Concrete/SharedProcurementEntryService.cs
@@ -66,5 +66,14 @@ namespace DogrudanTeminParadiseAPI.Service.Concrete
 
             return _mapper.Map<SharedProcurementEntryDto>(shared);
         }
+
+        public async Task DeleteAsync(Guid id)
+        {
+            var existing = await _repo.GetByIdAsync(id);
+            if (existing == null)
+                throw new KeyNotFoundException("Paylaşım bulunamadı.");
+
+            await _repo.DeleteAsync(id);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- expose delete endpoint for shared entries
- handle delete logic in service
- update service interface with delete method

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880ac00f73c83239ca785f364fddeaf