### PR TITLE
Add one-source procurement documents module

### DIFF
--- a/DogrudanTeminParadiseAPI/Controllers/OSProcurementEntryDocumentsController.cs
+++ b/DogrudanTeminParadiseAPI/Controllers/OSProcurementEntryDocumentsController.cs
@@ -1,0 +1,48 @@
+using DogrudanTeminParadiseAPI.Dto;
+using DogrudanTeminParadiseAPI.Service.Abstract;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DogrudanTeminParadiseAPI.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    [Authorize]
+    public class OSProcurementEntryDocumentsController : ControllerBase
+    {
+        private readonly IOSProcurementEntryDocumentsService _svc;
+        public OSProcurementEntryDocumentsController(IOSProcurementEntryDocumentsService svc) => _svc = svc;
+
+        [HttpPost]
+        public async Task<IActionResult> Create([FromBody] CreateOSProcurementEntryDocumentsDto dto)
+        {
+            var created = await _svc.CreateAsync(dto);
+            return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
+        }
+
+        [HttpGet("entry/{entryId}")]
+        public async Task<IActionResult> GetAllByEntry(Guid entryId)
+            => Ok(await _svc.GetAllByEntryAsync(entryId));
+
+        [HttpGet("{id}")]
+        public async Task<IActionResult> GetById(Guid id)
+        {
+            var doc = await _svc.GetByIdAsync(id);
+            return doc == null ? NotFound() : Ok(doc);
+        }
+
+        [HttpPut("{id}")]
+        public async Task<IActionResult> Update(Guid id, [FromBody] UpdateOSProcurementEntryDocumentsDto dto)
+        {
+            var updated = await _svc.UpdateAsync(id, dto);
+            return updated == null ? NotFound() : Ok(updated);
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(Guid id)
+        {
+            await _svc.DeleteAsync(id);
+            return NoContent();
+        }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Dto/CreateOSProcurementEntryDocumentsDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/CreateOSProcurementEntryDocumentsDto.cs
@@ -1,0 +1,8 @@
+namespace DogrudanTeminParadiseAPI.Dto
+{
+    public class CreateOSProcurementEntryDocumentsDto
+    {
+        public Guid OneSourceProcurementEntryId { get; set; }
+        public List<byte[]> EntrepriseFiles { get; set; } = new();
+    }
+}

--- a/DogrudanTeminParadiseAPI/Dto/OSProcurementEntryDocumentsDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/OSProcurementEntryDocumentsDto.cs
@@ -1,0 +1,10 @@
+namespace DogrudanTeminParadiseAPI.Dto
+{
+    public class OSProcurementEntryDocumentsDto
+    {
+        public Guid Id { get; set; }
+        public Guid OneSourceProcurementEntryId { get; set; }
+        public List<byte[]> EntrepriseFiles { get; set; }
+        public DateTime TransactionAt { get; set; }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Dto/UpdateOSProcurementEntryDocumentsDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/UpdateOSProcurementEntryDocumentsDto.cs
@@ -1,0 +1,7 @@
+namespace DogrudanTeminParadiseAPI.Dto
+{
+    public class UpdateOSProcurementEntryDocumentsDto
+    {
+        public List<byte[]> EntrepriseFiles { get; set; } = new();
+    }
+}

--- a/DogrudanTeminParadiseAPI/Helpers/HelperClasses.cs
+++ b/DogrudanTeminParadiseAPI/Helpers/HelperClasses.cs
@@ -68,4 +68,11 @@ namespace DogrudanTeminParadiseAPI.Helpers
         PRODUCT,
         SERVICE
     }
+
+    public enum KanunMaddesi
+    {
+        _22A,
+        _22B,
+        _22C
+    }
 }

--- a/DogrudanTeminParadiseAPI/Mapping/MappingProfile.cs
+++ b/DogrudanTeminParadiseAPI/Mapping/MappingProfile.cs
@@ -183,6 +183,10 @@ namespace DogrudanTeminParadiseAPI.Mapping
             CreateMap<BudgetItem, BudgetItemCountDto>();
             CreateMap<BudgetItem, BudgetItemPaymentDto>();
             CreateMap<BudgetItem, BudgetItemOfferStatDto>();
+
+            CreateMap<CreateOSProcurementEntryDocumentsDto, OSProcurementEntryDocuments>();
+            CreateMap<UpdateOSProcurementEntryDocumentsDto, OSProcurementEntryDocuments>();
+            CreateMap<OSProcurementEntryDocuments, OSProcurementEntryDocumentsDto>();
         }
     }
 }

--- a/DogrudanTeminParadiseAPI/Models/OSAdditionalInspectionAcceptanceCertificate.cs
+++ b/DogrudanTeminParadiseAPI/Models/OSAdditionalInspectionAcceptanceCertificate.cs
@@ -1,0 +1,29 @@
+using DogrudanTeminParadiseAPI.Helpers;
+using DogrudanTeminParadiseAPI.Dto;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace DogrudanTeminParadiseAPI.Models
+{
+    public class OSAdditionalInspectionAcceptanceCertificate
+    {
+        [BsonId]
+        [BsonRepresentation(BsonType.String)]
+        public Guid Id { get; set; }
+
+        [BsonRepresentation(BsonType.String)]
+        public Guid OneSourceProcurementEntryId { get; set; }
+
+        [BsonRepresentation(BsonType.String)]
+        public Guid AdministrationUnitId { get; set; }
+        [BsonRepresentation(BsonType.String)]
+        public Guid SubAdministrationUnitId { get; set; }
+        [BsonRepresentation(BsonType.String)]
+        public Guid ThreeSubAdministrationUnitId { get; set; }
+        public List<SelectedOfferItem> SelectedProducts { get; set; } = new();
+        [BsonRepresentation(BsonType.String)]
+        public Guid SelectedOfferLetterId { get; set; }
+        public DateTime InvoiceDate { get; set; }
+        public string InvoiceNumber { get; set; }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Models/OSInspectionAcceptanceCertificate.cs
+++ b/DogrudanTeminParadiseAPI/Models/OSInspectionAcceptanceCertificate.cs
@@ -1,0 +1,31 @@
+using DogrudanTeminParadiseAPI.Dto;
+using DogrudanTeminParadiseAPI.Helpers;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace DogrudanTeminParadiseAPI.Models
+{
+    public class OSInspectionAcceptanceCertificate
+    {
+        [BsonId]
+        [BsonRepresentation(BsonType.String)]
+        public Guid Id { get; set; }
+
+        [BsonRepresentation(BsonType.String)]
+        public Guid OneSourceProcurementEntryId { get; set; }
+
+        public string InvoiceNumber { get; set; }
+        public DateTime InvoiceDate { get; set; }
+
+        public List<SelectedOfferItem> SelectedProducts { get; set; } = new();
+
+        [BsonRepresentation(BsonType.String)]
+        public Guid AdministrationUnitId { get; set; }
+        [BsonRepresentation(BsonType.String)]
+        public Guid SubAdministrationUnitId { get; set; }
+        [BsonRepresentation(BsonType.String)]
+        public Guid ThreeSubAdministrationUnitId { get; set; }
+        [BsonRepresentation(BsonType.String)]
+        public Guid SelectedOfferLetterId { get; set; }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Models/OSInspectionAcceptanceJury.cs
+++ b/DogrudanTeminParadiseAPI/Models/OSInspectionAcceptanceJury.cs
@@ -1,0 +1,24 @@
+using DogrudanTeminParadiseAPI.Helpers;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace DogrudanTeminParadiseAPI.Models
+{
+    public class OSInspectionAcceptanceJury
+    {
+        [BsonId]
+        [BsonRepresentation(BsonType.String)]
+        public Guid Id { get; set; }
+
+        [BsonRepresentation(BsonType.String)]
+        public Guid OneSourceProcurementEntryId { get; set; }
+
+        [BsonRepresentation(BsonType.String)]
+        public Guid InspectionAcceptanceJuryId { get; set; }
+
+        public JuryType Type { get; set; } = JuryType.INSPECTION_ACCEPTANCE;
+
+        [BsonRepresentation(BsonType.String)]
+        public List<Guid> UserIds { get; set; } = new();
+    }
+}

--- a/DogrudanTeminParadiseAPI/Models/OSMarketResearchJury.cs
+++ b/DogrudanTeminParadiseAPI/Models/OSMarketResearchJury.cs
@@ -1,0 +1,22 @@
+using DogrudanTeminParadiseAPI.Helpers;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace DogrudanTeminParadiseAPI.Models
+{
+    public class OSMarketResearchJury
+    {
+        [BsonId]
+        [BsonRepresentation(BsonType.String)]
+        public Guid Id { get; set; }
+
+        [BsonRepresentation(BsonType.String)]
+        public Guid OneSourceProcurementEntryId { get; set; }
+
+        [BsonRepresentation(BsonType.String)]
+        public JuryType Type { get; set; } = JuryType.MARKET_RESEARCH;
+
+        [BsonRepresentation(BsonType.String)]
+        public List<Guid> UserIds { get; set; } = new();
+    }
+}

--- a/DogrudanTeminParadiseAPI/Models/OSOfferLetter.cs
+++ b/DogrudanTeminParadiseAPI/Models/OSOfferLetter.cs
@@ -1,0 +1,26 @@
+using DogrudanTeminParadiseAPI.Helpers;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace DogrudanTeminParadiseAPI.Models
+{
+    public class OSOfferLetter
+    {
+        [BsonId]
+        [BsonRepresentation(BsonType.String)]
+        public Guid Id { get; set; }
+
+        [BsonRepresentation(BsonType.String)]
+        public Guid EntrepriseId { get; set; }
+
+        [BsonRepresentation(BsonType.String)]
+        public Guid OneSourceProcurementEntryId { get; set; }
+
+        public List<OfferItem> OfferItems { get; set; } = new();
+        public string ResponsiblePerson { get; set; }
+        public string Vkn { get; set; }
+        public string NotificationAddress { get; set; }
+        public string Email { get; set; }
+        public string Nationality { get; set; }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Models/OSProcurementEntryDocuments.cs
+++ b/DogrudanTeminParadiseAPI/Models/OSProcurementEntryDocuments.cs
@@ -1,0 +1,19 @@
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace DogrudanTeminParadiseAPI.Models
+{
+    public class OSProcurementEntryDocuments
+    {
+        [BsonId]
+        [BsonRepresentation(BsonType.String)]
+        public Guid Id { get; set; }
+
+        [BsonRepresentation(BsonType.String)]
+        public Guid OneSourceProcurementEntryId { get; set; }
+
+        public List<byte[]> EntrepriseFiles { get; set; } = new();
+
+        public DateTime TransactionAt { get; set; }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Models/OSProcurementEntryEditor.cs
+++ b/DogrudanTeminParadiseAPI/Models/OSProcurementEntryEditor.cs
@@ -1,0 +1,17 @@
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace DogrudanTeminParadiseAPI.Models
+{
+    public class OSProcurementEntryEditor
+    {
+        [BsonId]
+        [BsonRepresentation(BsonType.String)]
+        public Guid Id { get; set; }
+
+        [BsonRepresentation(BsonType.String)]
+        public Guid OneSourceProcurementEntryId { get; set; }
+
+        public List<OfferItem> OfferItems { get; set; } = new();
+    }
+}

--- a/DogrudanTeminParadiseAPI/Models/OneSourceProcurementEntry.cs
+++ b/DogrudanTeminParadiseAPI/Models/OneSourceProcurementEntry.cs
@@ -1,0 +1,52 @@
+using DogrudanTeminParadiseAPI.Helpers;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace DogrudanTeminParadiseAPI.Models
+{
+    public class OneSourceProcurementEntry
+    {
+        [BsonId]
+        [BsonRepresentation(BsonType.String)]
+        public Guid Id { get; set; }
+
+        public DateTime? ProcurementDecisionDate { get; set; }
+        public string? ProcurementDecisionNumber { get; set; }
+
+        [BsonRepresentation(BsonType.String)]
+        public Guid? TenderResponsibleUserId { get; set; }
+        public string? TenderResponsibleTitle { get; set; }
+
+        public string? WorkName { get; set; }
+        public string? WorkReason { get; set; }
+        [BsonRepresentation(BsonType.String)]
+        public Guid? BudgetAllocationId { get; set; }
+        public bool SpecificationToBePrepared { get; set; }
+        public bool ContractToBePrepared { get; set; }
+
+        public DateTime? PiyasaArastirmaOnayDate { get; set; }
+        public string? PiyasaArastirmaOnayNumber { get; set; }
+
+        public DateTime? TeklifMektubuDate { get; set; }
+        public string? TeklifMektubuNumber { get; set; }
+
+        public DateTime? PiyasaArastirmaBaslangicDate { get; set; }
+        public string? PiyasaArastirmaBaslangicNumber { get; set; }
+
+        public DateTime? YaklasikMaliyetHesaplamaBaslangicDate { get; set; }
+        public string? YaklasikMaliyetHesaplamaBaslangicNumber { get; set; }
+
+        public DateTime? MuayeneVeKabulBelgesiDate { get; set; }
+        public string? MuayeneVeKabulBelgesiNumber { get; set; }
+
+        [BsonRepresentation(BsonType.String)]
+        public Guid? AdministrationUnitId { get; set; }
+        [BsonRepresentation(BsonType.String)]
+        public Guid? SubAdministrationUnitId { get; set; }
+        [BsonRepresentation(BsonType.String)]
+        public Guid? ThreeSubAdministrationUnitId { get; set; }
+
+        public KanunMaddesi KanunMaddesi { get; set; }
+        public List<string> TekKaynakTeminNedenleri { get; set; } = new();
+    }
+}

--- a/DogrudanTeminParadiseAPI/Program.cs
+++ b/DogrudanTeminParadiseAPI/Program.cs
@@ -86,6 +86,7 @@ builder.Services.AddScoped(sp => new MongoDBRepository<SharedProcurementEntry>(c
 builder.Services.AddScoped(sp => new MongoDBRepository<UserNotification>(cfg["MongoAPI"], cfg["MongoDBName"], "UserNotifications"));
 builder.Services.AddScoped(sp => new MongoDBRepository<BackupUserNotification>(cfg["MongoAPI"], cfg["MongoBackupDBName"], "BackupUserNotifications"));
 builder.Services.AddScoped(sp => new MongoDBRepository<Notification>(cfg["MongoAPI"], cfg["MongoDBName"], "Notifications"));
+builder.Services.AddScoped(sp => new MongoDBRepository<OSProcurementEntryDocuments>(cfg["MongoAPI"], cfg["MongoDBName"], "OSProcurementEntryDocuments"));
 
 builder.Services.AddSingleton<IMongoClient>(sp =>
     new MongoClient(cfg["MongoAPI"])
@@ -140,6 +141,7 @@ builder.Services.AddScoped<ISharedProcurementEntryService, SharedProcurementEntr
 builder.Services.AddScoped<IUserNotificationService, UserNotificationService>();
 builder.Services.AddScoped<IBackupUserNotificationService, BackupUserNotificationService>();
 builder.Services.AddScoped<INotificationService, NotificationService>();
+builder.Services.AddScoped<IOSProcurementEntryDocumentsService, OSProcurementEntryDocumentsService>();
 // Factoryler
 builder.Services.AddSingleton<ITeminApiExceptionFactory, TeminApiExceptionFactory>();
 

--- a/DogrudanTeminParadiseAPI/Service/Abstract/IOSProcurementEntryDocumentsService.cs
+++ b/DogrudanTeminParadiseAPI/Service/Abstract/IOSProcurementEntryDocumentsService.cs
@@ -1,0 +1,13 @@
+using DogrudanTeminParadiseAPI.Dto;
+
+namespace DogrudanTeminParadiseAPI.Service.Abstract
+{
+    public interface IOSProcurementEntryDocumentsService
+    {
+        Task<OSProcurementEntryDocumentsDto> CreateAsync(CreateOSProcurementEntryDocumentsDto dto);
+        Task<IEnumerable<OSProcurementEntryDocumentsDto>> GetAllByEntryAsync(Guid entryId);
+        Task<OSProcurementEntryDocumentsDto> GetByIdAsync(Guid id);
+        Task<OSProcurementEntryDocumentsDto> UpdateAsync(Guid id, UpdateOSProcurementEntryDocumentsDto dto);
+        Task DeleteAsync(Guid id);
+    }
+}

--- a/DogrudanTeminParadiseAPI/Service/Concrete/OSProcurementEntryDocumentsService.cs
+++ b/DogrudanTeminParadiseAPI/Service/Concrete/OSProcurementEntryDocumentsService.cs
@@ -1,0 +1,56 @@
+using AutoMapper;
+using DogrudanTeminParadiseAPI.Dto;
+using DogrudanTeminParadiseAPI.Models;
+using DogrudanTeminParadiseAPI.Repositories;
+using DogrudanTeminParadiseAPI.Service.Abstract;
+
+namespace DogrudanTeminParadiseAPI.Service.Concrete
+{
+    public class OSProcurementEntryDocumentsService : IOSProcurementEntryDocumentsService
+    {
+        private readonly MongoDBRepository<OSProcurementEntryDocuments> _repo;
+        private readonly IMapper _mapper;
+
+        public OSProcurementEntryDocumentsService(MongoDBRepository<OSProcurementEntryDocuments> repo, IMapper mapper)
+        {
+            _repo = repo;
+            _mapper = mapper;
+        }
+
+        public async Task<OSProcurementEntryDocumentsDto> CreateAsync(CreateOSProcurementEntryDocumentsDto dto)
+        {
+            var entity = _mapper.Map<OSProcurementEntryDocuments>(dto);
+            entity.Id = Guid.NewGuid();
+            entity.TransactionAt = DateTime.UtcNow;
+            await _repo.InsertAsync(entity);
+            return _mapper.Map<OSProcurementEntryDocumentsDto>(entity);
+        }
+
+        public async Task DeleteAsync(Guid id)
+        {
+            await _repo.DeleteAsync(id);
+        }
+
+        public async Task<IEnumerable<OSProcurementEntryDocumentsDto>> GetAllByEntryAsync(Guid entryId)
+        {
+            var list = await _repo.GetAllAsync();
+            return list.Where(d => d.OneSourceProcurementEntryId == entryId)
+                       .Select(d => _mapper.Map<OSProcurementEntryDocumentsDto>(d));
+        }
+
+        public async Task<OSProcurementEntryDocumentsDto> GetByIdAsync(Guid id)
+        {
+            var entity = await _repo.GetByIdAsync(id);
+            return entity == null ? null : _mapper.Map<OSProcurementEntryDocumentsDto>(entity);
+        }
+
+        public async Task<OSProcurementEntryDocumentsDto> UpdateAsync(Guid id, UpdateOSProcurementEntryDocumentsDto dto)
+        {
+            var entity = await _repo.GetByIdAsync(id);
+            if (entity == null) return null;
+            entity.EntrepriseFiles = dto.EntrepriseFiles;
+            await _repo.UpdateAsync(id, entity);
+            return _mapper.Map<OSProcurementEntryDocumentsDto>(entity);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `KanunMaddesi` enum
- add new models for One Source procurement features
- create DTOs, service, and controller for `OSProcurementEntryDocuments`
- map new DTOs in AutoMapper profile
- register repository and service in `Program.cs`

## Testing
- `dotnet build` *(fails: `dotnet` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6881fcd102588323a24172fda6e63902