### PR TITLE
Add one-source procurement entry with GridFS docs

### DIFF
--- a/DogrudanTeminParadiseAPI/Controllers/OSAdditionalInspectionAcceptanceController.cs
+++ b/DogrudanTeminParadiseAPI/Controllers/OSAdditionalInspectionAcceptanceController.cs
@@ -1,0 +1,66 @@
+using DogrudanTeminParadiseAPI.Dto;
+using DogrudanTeminParadiseAPI.Helpers.Attributes;
+using DogrudanTeminParadiseAPI.Service.Abstract;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+
+namespace DogrudanTeminParadiseAPI.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    [Authorize]
+    [CallLogs]
+    public class OSAdditionalInspectionAcceptanceController : ControllerBase
+    {
+        private readonly IOSAdditionalInspectionAcceptanceService _svc;
+
+        public OSAdditionalInspectionAcceptanceController(IOSAdditionalInspectionAcceptanceService svc)
+        {
+            _svc = svc;
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> Create([FromBody] CreateOSAdditionalInspectionAcceptanceCertificateDto dto)
+        {
+            var created = await _svc.CreateAsync(dto);
+            return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> GetAll()
+        {
+            var list = await _svc.GetAllAsync();
+            return Ok(list);
+        }
+
+        [HttpGet("entry/{entryId}")]
+        public async Task<IActionResult> GetAllByEntry(Guid entryId)
+        {
+            var list = await _svc.GetAllByEntryAsync(entryId);
+            return Ok(list);
+        }
+
+        [HttpGet("{id}")]
+        public async Task<IActionResult> GetById(Guid id)
+        {
+            var dto = await _svc.GetByIdAsync(id);
+            return dto == null ? NotFound() : Ok(dto);
+        }
+
+        [HttpPut("{id}")]
+        public async Task<IActionResult> Update(Guid id, [FromBody] UpdateOSAdditionalInspectionAcceptanceCertificateDto dto)
+        {
+            var updated = await _svc.UpdateAsync(id, dto);
+            return updated == null ? NotFound() : Ok(updated);
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(Guid id)
+        {
+            var userId = Guid.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier));
+            await _svc.DeleteAsync(id, userId);
+            return NoContent();
+        }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Controllers/OSInspectionAcceptanceCertificateController.cs
+++ b/DogrudanTeminParadiseAPI/Controllers/OSInspectionAcceptanceCertificateController.cs
@@ -1,0 +1,62 @@
+using DogrudanTeminParadiseAPI.Dto;
+using DogrudanTeminParadiseAPI.Helpers.Attributes;
+using DogrudanTeminParadiseAPI.Service.Abstract;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+
+namespace DogrudanTeminParadiseAPI.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    [Authorize]
+    [CallLogs]
+    public class OSInspectionAcceptanceCertificateController : ControllerBase
+    {
+        private readonly IOSInspectionAcceptanceCertificateService _svc;
+        public OSInspectionAcceptanceCertificateController(IOSInspectionAcceptanceCertificateService svc) => _svc = svc;
+
+        [HttpPost]
+        public async Task<IActionResult> Create([FromBody] CreateOSInspectionAcceptanceCertificateDto dto)
+        {
+            var created = await _svc.CreateAsync(dto);
+            return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> GetAll()
+        {
+            var list = await _svc.GetAllAsync();
+            return Ok(list);
+        }
+
+        [HttpGet("entry/{entryId}")]
+        public async Task<IActionResult> GetAllByEntry(Guid entryId)
+        {
+            var list = await _svc.GetAllByEntryAsync(entryId);
+            return Ok(list);
+        }
+
+        [HttpGet("{id}")]
+        public async Task<IActionResult> GetById(Guid id)
+        {
+            var dto = await _svc.GetByIdAsync(id);
+            return dto == null ? NotFound() : Ok(dto);
+        }
+
+        [HttpPut("{id}")]
+        public async Task<IActionResult> Update(Guid id, [FromBody] UpdateOSInspectionAcceptanceCertificateDto dto)
+        {
+            var updated = await _svc.UpdateAsync(id, dto);
+            return updated == null ? NotFound() : Ok(updated);
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(Guid id)
+        {
+            var userId = Guid.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier));
+            await _svc.DeleteAsync(id, userId);
+            return NoContent();
+        }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Controllers/OSInspectionAcceptanceNoteController.cs
+++ b/DogrudanTeminParadiseAPI/Controllers/OSInspectionAcceptanceNoteController.cs
@@ -1,0 +1,56 @@
+using DogrudanTeminParadiseAPI.Dto;
+using DogrudanTeminParadiseAPI.Helpers.Attributes;
+using DogrudanTeminParadiseAPI.Service.Abstract;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DogrudanTeminParadiseAPI.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    [Authorize]
+    [CallLogs]
+    public class OSInspectionAcceptanceNotesController : ControllerBase
+    {
+        private readonly IOSInspectionAcceptanceNoteService _svc;
+        public OSInspectionAcceptanceNotesController(IOSInspectionAcceptanceNoteService svc)
+        {
+            _svc = svc;
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> Create([FromBody] CreateOSInspectionAcceptanceNoteDto dto)
+        {
+            var created = await _svc.CreateAsync(dto);
+            return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
+        }
+
+        [HttpGet("entry/{entryId}")]
+        public async Task<IActionResult> GetAllByEntry(Guid entryId)
+        {
+            var list = await _svc.GetAllByEntryAsync(entryId);
+            return Ok(list);
+        }
+
+        [HttpGet("{id}")]
+        public async Task<IActionResult> GetById(Guid id)
+        {
+            var item = await _svc.GetByIdAsync(id);
+            return item == null ? NotFound() : Ok(item);
+        }
+
+        [HttpPut("{id}")]
+        public async Task<IActionResult> Update(Guid id, [FromBody] UpdateOSInspectionAcceptanceNoteDto dto)
+        {
+            var updated = await _svc.UpdateAsync(id, dto);
+            return updated == null ? NotFound() : Ok(updated);
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(Guid id)
+        {
+            await _svc.DeleteAsync(id);
+            return NoContent();
+        }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Controllers/OSMarketResearchJuryController.cs
+++ b/DogrudanTeminParadiseAPI/Controllers/OSMarketResearchJuryController.cs
@@ -1,0 +1,44 @@
+using DogrudanTeminParadiseAPI.Dto;
+using DogrudanTeminParadiseAPI.Helpers.Attributes;
+using DogrudanTeminParadiseAPI.Service.Abstract;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DogrudanTeminParadiseAPI.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    [Authorize]
+    [CallLogs]
+    public class OSMarketResearchJuryController : ControllerBase
+    {
+        private readonly IOSMarketResearchJuryService _svc;
+        public OSMarketResearchJuryController(IOSMarketResearchJuryService svc) => _svc = svc;
+
+        [HttpPost]
+        public async Task<IActionResult> Create([FromBody] CreateOSMarketResearchJuryDto dto)
+        {
+            var created = await _svc.CreateAsync(dto);
+            return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
+        }
+
+        [HttpGet("entry/{entryId}")]
+        public async Task<IActionResult> GetAllByEntry(Guid entryId)
+            => Ok(await _svc.GetAllByEntryAsync(entryId));
+
+        [HttpGet("{id}")]
+        public async Task<IActionResult> GetById(Guid id)
+            => (await _svc.GetByIdAsync(id)) is var dto && dto != null ? Ok(dto) : NotFound();
+
+        [HttpPut("{id}")]
+        public async Task<IActionResult> Update(Guid id, [FromBody] UpdateOSMarketResearchJuryDto dto)
+            => Ok(await _svc.UpdateAsync(id, dto));
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(Guid id)
+        {
+            await _svc.DeleteAsync(id);
+            return NoContent();
+        }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Controllers/OSOfferLetterController.cs
+++ b/DogrudanTeminParadiseAPI/Controllers/OSOfferLetterController.cs
@@ -1,0 +1,63 @@
+using DogrudanTeminParadiseAPI.Dto;
+using DogrudanTeminParadiseAPI.Helpers.Attributes;
+using DogrudanTeminParadiseAPI.Service.Abstract;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+
+namespace DogrudanTeminParadiseAPI.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    [Authorize]
+    [CallLogs]
+    public class OSOfferLetterController : ControllerBase
+    {
+        private readonly IOSOfferLetterService _svc;
+        public OSOfferLetterController(IOSOfferLetterService svc) => _svc = svc;
+
+        [HttpPost]
+        public async Task<IActionResult> Create([FromBody] CreateOSOfferLetterDto dto)
+        {
+            var created = await _svc.CreateAsync(dto);
+            return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> GetAll()
+            => Ok(await _svc.GetAllAsync());
+
+        [HttpGet("entry/{entryId}")]
+        public async Task<IActionResult> GetAllByEntry(Guid entryId)
+            => Ok(await _svc.GetAllByEntryAsync(entryId));
+
+        [HttpGet("{id}")]
+        public async Task<IActionResult> GetById(Guid id)
+        {
+            var item = await _svc.GetByIdAsync(id);
+            return item == null ? NotFound() : Ok(item);
+        }
+
+        [HttpPut("{id}")]
+        public async Task<IActionResult> Update(Guid id, [FromBody] UpdateOSOfferLetterDto dto)
+        {
+            var updated = await _svc.UpdateAsync(id, dto);
+            return updated == null ? NotFound() : Ok(updated);
+        }
+
+        [HttpPut("entry/{entryId}/items")]
+        public async Task<IActionResult> UpdateItemsByEntry(Guid entryId, [FromBody] UpdateOSOfferItemsByEntryDto dto)
+        {
+            var updated = await _svc.UpdateItemsByEntryAsync(entryId, dto);
+            return Ok(updated);
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(Guid id)
+        {
+            var userId = Guid.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier));
+            await _svc.DeleteAsync(id, userId);
+            return NoContent();
+        }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Controllers/OSProcurementEntryController.cs
+++ b/DogrudanTeminParadiseAPI/Controllers/OSProcurementEntryController.cs
@@ -1,0 +1,49 @@
+using DogrudanTeminParadiseAPI.Dto;
+using DogrudanTeminParadiseAPI.Helpers.Attributes;
+using DogrudanTeminParadiseAPI.Service.Abstract;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DogrudanTeminParadiseAPI.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    [Authorize]
+    [CallLogs]
+    public class OSProcurementEntryController : ControllerBase
+    {
+        private readonly IOSProcurementEntryService _svc;
+        public OSProcurementEntryController(IOSProcurementEntryService svc) => _svc = svc;
+
+        [HttpPost]
+        public async Task<IActionResult> Create([FromBody] CreateOSProcurementEntryDto dto)
+        {
+            var created = await _svc.CreateAsync(dto);
+            return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> GetAll() => Ok(await _svc.GetAllAsync());
+
+        [HttpGet("{id}")]
+        public async Task<IActionResult> GetById(Guid id)
+        {
+            var item = await _svc.GetByIdAsync(id);
+            return item == null ? NotFound() : Ok(item);
+        }
+
+        [HttpPut("{id}")]
+        public async Task<IActionResult> Update(Guid id, [FromBody] UpdateOSProcurementEntryDto dto)
+        {
+            var updated = await _svc.UpdateAsync(id, dto);
+            return updated == null ? NotFound() : Ok(updated);
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(Guid id)
+        {
+            await _svc.DeleteAsync(id);
+            return NoContent();
+        }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Controllers/OSProcurementEntryDocumentsController.cs
+++ b/DogrudanTeminParadiseAPI/Controllers/OSProcurementEntryDocumentsController.cs
@@ -1,0 +1,48 @@
+using DogrudanTeminParadiseAPI.Dto;
+using DogrudanTeminParadiseAPI.Service.Abstract;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DogrudanTeminParadiseAPI.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    [Authorize]
+    public class OSProcurementEntryDocumentsController : ControllerBase
+    {
+        private readonly IOSProcurementEntryDocumentsService _svc;
+        public OSProcurementEntryDocumentsController(IOSProcurementEntryDocumentsService svc) => _svc = svc;
+
+        [HttpPost]
+        public async Task<IActionResult> Create([FromBody] CreateOSProcurementEntryDocumentsDto dto)
+        {
+            var created = await _svc.CreateAsync(dto);
+            return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
+        }
+
+        [HttpGet("entry/{entryId}")]
+        public async Task<IActionResult> GetAllByEntry(Guid entryId)
+            => Ok(await _svc.GetAllByEntryAsync(entryId));
+
+        [HttpGet("{id}")]
+        public async Task<IActionResult> GetById(Guid id)
+        {
+            var doc = await _svc.GetByIdAsync(id);
+            return doc == null ? NotFound() : Ok(doc);
+        }
+
+        [HttpPut("{id}")]
+        public async Task<IActionResult> Update(Guid id, [FromBody] UpdateOSProcurementEntryDocumentsDto dto)
+        {
+            var updated = await _svc.UpdateAsync(id, dto);
+            return updated == null ? NotFound() : Ok(updated);
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(Guid id)
+        {
+            await _svc.DeleteAsync(id);
+            return NoContent();
+        }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Controllers/OSProcurementEntryEditorController.cs
+++ b/DogrudanTeminParadiseAPI/Controllers/OSProcurementEntryEditorController.cs
@@ -1,0 +1,53 @@
+using DogrudanTeminParadiseAPI.Dto;
+using DogrudanTeminParadiseAPI.Helpers.Attributes;
+using DogrudanTeminParadiseAPI.Service.Abstract;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DogrudanTeminParadiseAPI.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    [Authorize]
+    [CallLogs]
+    public class OSProcurementEntryEditorController : ControllerBase
+    {
+        private readonly IOSProcurementEntryEditorService _svc;
+        public OSProcurementEntryEditorController(IOSProcurementEntryEditorService svc) => _svc = svc;
+
+        [HttpGet]
+        public async Task<IActionResult> Get()
+        {
+            var dto = await _svc.GetAsync();
+            return dto == null ? NotFound() : Ok(dto);
+        }
+
+        [HttpGet("{id}")]
+        public async Task<IActionResult> GetById(Guid id)
+        {
+            var dto = await _svc.GetByIdAsync(id);
+            return dto == null ? NotFound() : Ok(dto);
+        }
+
+        [HttpGet("entry/{entryId}")]
+        public async Task<IActionResult> GetByEntry(Guid entryId)
+        {
+            var dto = await _svc.GetEditorByEntryIdAsync(entryId);
+            return dto == null ? NotFound() : Ok(dto);
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> Create([FromBody] CreateOSProcurementEntryEditorDto dto)
+        {
+            var created = await _svc.CreateAsync(dto);
+            return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
+        }
+
+        [HttpPut]
+        public async Task<IActionResult> Update([FromBody] UpdateOSProcurementEntryEditorDto dto)
+        {
+            var updated = await _svc.UpdateAsync(dto);
+            return updated == null ? NotFound() : Ok(updated);
+        }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Dto/CreateOSAdditionalInspectionAcceptanceCertificateDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/CreateOSAdditionalInspectionAcceptanceCertificateDto.cs
@@ -1,0 +1,16 @@
+using DogrudanTeminParadiseAPI.Helpers;
+
+namespace DogrudanTeminParadiseAPI.Dto
+{
+    public class CreateOSAdditionalInspectionAcceptanceCertificateDto
+    {
+        public Guid OneSourceProcurementEntryId { get; set; }
+        public Guid AdministrationUnitId { get; set; }
+        public Guid SubAdministrationUnitId { get; set; }
+        public Guid ThreeSubAdministrationUnitId { get; set; }
+        public List<SelectedOfferItem> SelectedProducts { get; set; } = new();
+        public Guid SelectedOfferLetterId { get; set; }
+        public DateTime InvoiceDate { get; set; }
+        public string InvoiceNumber { get; set; }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Dto/CreateOSInspectionAcceptanceCertificateDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/CreateOSInspectionAcceptanceCertificateDto.cs
@@ -1,0 +1,16 @@
+using DogrudanTeminParadiseAPI.Helpers;
+
+namespace DogrudanTeminParadiseAPI.Dto
+{
+    public class CreateOSInspectionAcceptanceCertificateDto
+    {
+        public Guid OneSourceProcurementEntryId { get; set; }
+        public string InvoiceNumber { get; set; }
+        public DateTime InvoiceDate { get; set; }
+        public List<SelectedOfferItem> SelectedProducts { get; set; } = new();
+        public Guid AdministrationUnitId { get; set; }
+        public Guid SubAdministrationUnitId { get; set; }
+        public Guid ThreeSubAdministrationUnitId { get; set; }
+        public Guid SelectedOfferLetterId { get; set; }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Dto/CreateOSInspectionAcceptanceNoteDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/CreateOSInspectionAcceptanceNoteDto.cs
@@ -1,0 +1,8 @@
+namespace DogrudanTeminParadiseAPI.Dto
+{
+    public class CreateOSInspectionAcceptanceNoteDto
+    {
+        public Guid OneSourceProcurementEntryId { get; set; }
+        public string Note { get; set; }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Dto/CreateOSMarketResearchJuryDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/CreateOSMarketResearchJuryDto.cs
@@ -1,0 +1,8 @@
+namespace DogrudanTeminParadiseAPI.Dto
+{
+    public class CreateOSMarketResearchJuryDto
+    {
+        public Guid OneSourceProcurementEntryId { get; set; }
+        public List<Guid> UserIds { get; set; } = new();
+    }
+}

--- a/DogrudanTeminParadiseAPI/Dto/CreateOSOfferLetterDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/CreateOSOfferLetterDto.cs
@@ -1,0 +1,14 @@
+namespace DogrudanTeminParadiseAPI.Dto
+{
+    public class CreateOSOfferLetterDto
+    {
+        public Guid EntrepriseId { get; set; }
+        public Guid OneSourceProcurementEntryId { get; set; }
+        public List<CreateOfferItemDto> OfferItems { get; set; } = new();
+        public string NotificationAddress { get; set; }
+        public string Email { get; set; }
+        public string Nationality { get; set; }
+        public string ResponsiblePerson { get; set; }
+        public string Vkn { get; set; }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Dto/CreateOSProcurementEntryDocumentsDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/CreateOSProcurementEntryDocumentsDto.cs
@@ -1,0 +1,8 @@
+namespace DogrudanTeminParadiseAPI.Dto
+{
+    public class CreateOSProcurementEntryDocumentsDto
+    {
+        public Guid OneSourceProcurementEntryId { get; set; }
+        public List<byte[]> EntrepriseFiles { get; set; } = new();
+    }
+}

--- a/DogrudanTeminParadiseAPI/Dto/CreateOSProcurementEntryDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/CreateOSProcurementEntryDto.cs
@@ -1,0 +1,31 @@
+using DogrudanTeminParadiseAPI.Helpers;
+namespace DogrudanTeminParadiseAPI.Dto
+{
+    public class CreateOSProcurementEntryDto
+    {
+        public DateTime? ProcurementDecisionDate { get; set; }
+        public string? ProcurementDecisionNumber { get; set; }
+        public Guid? TenderResponsibleUserId { get; set; }
+        public string? TenderResponsibleTitle { get; set; }
+        public string? WorkName { get; set; }
+        public string? WorkReason { get; set; }
+        public Guid? BudgetAllocationId { get; set; }
+        public bool SpecificationToBePrepared { get; set; }
+        public bool ContractToBePrepared { get; set; }
+        public DateTime? PiyasaArastirmaOnayDate { get; set; }
+        public string? PiyasaArastirmaOnayNumber { get; set; }
+        public DateTime? TeklifMektubuDate { get; set; }
+        public string? TeklifMektubuNumber { get; set; }
+        public DateTime? PiyasaArastirmaBaslangicDate { get; set; }
+        public string? PiyasaArastirmaBaslangicNumber { get; set; }
+        public DateTime? YaklasikMaliyetHesaplamaBaslangicDate { get; set; }
+        public string? YaklasikMaliyetHesaplamaBaslangicNumber { get; set; }
+        public DateTime? MuayeneVeKabulBelgesiDate { get; set; }
+        public string? MuayeneVeKabulBelgesiNumber { get; set; }
+        public Guid? AdministrationUnitId { get; set; }
+        public Guid? SubAdministrationUnitId { get; set; }
+        public Guid? ThreeSubAdministrationUnitId { get; set; }
+        public KanunMaddesi KanunMaddesi { get; set; }
+        public List<string> TekKaynakTeminNedenleri { get; set; } = new();
+    }
+}

--- a/DogrudanTeminParadiseAPI/Dto/CreateOSProcurementEntryEditorDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/CreateOSProcurementEntryEditorDto.cs
@@ -1,0 +1,8 @@
+namespace DogrudanTeminParadiseAPI.Dto
+{
+    public class CreateOSProcurementEntryEditorDto
+    {
+        public Guid OneSourceProcurementEntryId { get; set; }
+        public List<CreateOfferItemDto> OfferItems { get; set; } = new();
+    }
+}

--- a/DogrudanTeminParadiseAPI/Dto/OSAdditionalInspectionAcceptanceCertificateDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/OSAdditionalInspectionAcceptanceCertificateDto.cs
@@ -1,0 +1,17 @@
+using DogrudanTeminParadiseAPI.Helpers;
+
+namespace DogrudanTeminParadiseAPI.Dto
+{
+    public class OSAdditionalInspectionAcceptanceCertificateDto
+    {
+        public Guid Id { get; set; }
+        public Guid OneSourceProcurementEntryId { get; set; }
+        public Guid AdministrationUnitId { get; set; }
+        public Guid SubAdministrationUnitId { get; set; }
+        public Guid ThreeSubAdministrationUnitId { get; set; }
+        public List<SelectedOfferItem> SelectedProducts { get; set; }
+        public Guid SelectedOfferLetterId { get; set; }
+        public DateTime InvoiceDate { get; set; }
+        public string InvoiceNumber { get; set; }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Dto/OSInspectionAcceptanceCertificateDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/OSInspectionAcceptanceCertificateDto.cs
@@ -1,0 +1,17 @@
+using DogrudanTeminParadiseAPI.Helpers;
+
+namespace DogrudanTeminParadiseAPI.Dto
+{
+    public class OSInspectionAcceptanceCertificateDto
+    {
+        public Guid Id { get; set; }
+        public Guid OneSourceProcurementEntryId { get; set; }
+        public string InvoiceNumber { get; set; }
+        public DateTime InvoiceDate { get; set; }
+        public List<SelectedOfferItem> SelectedProducts { get; set; }
+        public Guid SelectedOfferLetterId { get; set; }
+        public Guid AdministrationUnitId { get; set; }
+        public Guid SubAdministrationUnitId { get; set; }
+        public Guid ThreeSubAdministrationUnitId { get; set; }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Dto/OSInspectionAcceptanceNoteDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/OSInspectionAcceptanceNoteDto.cs
@@ -1,0 +1,9 @@
+namespace DogrudanTeminParadiseAPI.Dto
+{
+    public class OSInspectionAcceptanceNoteDto
+    {
+        public Guid Id { get; set; }
+        public Guid OneSourceProcurementEntryId { get; set; }
+        public string Note { get; set; }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Dto/OSMarketResearchJuryDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/OSMarketResearchJuryDto.cs
@@ -1,0 +1,15 @@
+using DogrudanTeminParadiseAPI.Helpers;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace DogrudanTeminParadiseAPI.Dto
+{
+    public class OSMarketResearchJuryDto
+    {
+        public Guid Id { get; set; }
+        public Guid OneSourceProcurementEntryId { get; set; }
+        [BsonRepresentation(BsonType.String)]
+        public JuryType Type { get; set; }
+        public List<Guid> UserIds { get; set; } = [];
+    }
+}

--- a/DogrudanTeminParadiseAPI/Dto/OSOfferLetterDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/OSOfferLetterDto.cs
@@ -1,0 +1,17 @@
+using DogrudanTeminParadiseAPI.Helpers;
+
+namespace DogrudanTeminParadiseAPI.Dto
+{
+    public class OSOfferLetterDto
+    {
+        public Guid Id { get; set; }
+        public Guid EntrepriseId { get; set; }
+        public Guid OneSourceProcurementEntryId { get; set; }
+        public List<OfferItemDto> OfferItems { get; set; } = new();
+        public string ResponsiblePerson { get; set; }
+        public string Vkn { get; set; }
+        public string NotificationAddress { get; set; }
+        public string Email { get; set; }
+        public string Nationality { get; set; }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Dto/OSProcurementEntryDocumentsDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/OSProcurementEntryDocumentsDto.cs
@@ -1,0 +1,10 @@
+namespace DogrudanTeminParadiseAPI.Dto
+{
+    public class OSProcurementEntryDocumentsDto
+    {
+        public Guid Id { get; set; }
+        public Guid OneSourceProcurementEntryId { get; set; }
+        public List<string> EntrepriseFileIds { get; set; }
+        public DateTime TransactionAt { get; set; }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Dto/OSProcurementEntryDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/OSProcurementEntryDto.cs
@@ -1,0 +1,33 @@
+using DogrudanTeminParadiseAPI.Helpers;
+
+namespace DogrudanTeminParadiseAPI.Dto
+{
+    public class OSProcurementEntryDto
+    {
+        public Guid Id { get; set; }
+        public DateTime? ProcurementDecisionDate { get; set; }
+        public string? ProcurementDecisionNumber { get; set; }
+        public Guid? TenderResponsibleUserId { get; set; }
+        public string? TenderResponsibleTitle { get; set; }
+        public string? WorkName { get; set; }
+        public string? WorkReason { get; set; }
+        public Guid? BudgetAllocationId { get; set; }
+        public bool SpecificationToBePrepared { get; set; }
+        public bool ContractToBePrepared { get; set; }
+        public DateTime? PiyasaArastirmaOnayDate { get; set; }
+        public string? PiyasaArastirmaOnayNumber { get; set; }
+        public DateTime? TeklifMektubuDate { get; set; }
+        public string? TeklifMektubuNumber { get; set; }
+        public DateTime? PiyasaArastirmaBaslangicDate { get; set; }
+        public string? PiyasaArastirmaBaslangicNumber { get; set; }
+        public DateTime? YaklasikMaliyetHesaplamaBaslangicDate { get; set; }
+        public string? YaklasikMaliyetHesaplamaBaslangicNumber { get; set; }
+        public DateTime? MuayeneVeKabulBelgesiDate { get; set; }
+        public string? MuayeneVeKabulBelgesiNumber { get; set; }
+        public Guid? AdministrationUnitId { get; set; }
+        public Guid? SubAdministrationUnitId { get; set; }
+        public Guid? ThreeSubAdministrationUnitId { get; set; }
+        public KanunMaddesi KanunMaddesi { get; set; }
+        public List<string> TekKaynakTeminNedenleri { get; set; } = new();
+    }
+}

--- a/DogrudanTeminParadiseAPI/Dto/OSProcurementEntryEditorDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/OSProcurementEntryEditorDto.cs
@@ -1,0 +1,9 @@
+namespace DogrudanTeminParadiseAPI.Dto
+{
+    public class OSProcurementEntryEditorDto
+    {
+        public Guid Id { get; set; }
+        public Guid OneSourceProcurementEntryId { get; set; }
+        public List<OfferItemDto> OfferItems { get; set; }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Dto/UpdateOSAdditionalInspectionAcceptanceCertificateDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/UpdateOSAdditionalInspectionAcceptanceCertificateDto.cs
@@ -1,0 +1,15 @@
+using DogrudanTeminParadiseAPI.Helpers;
+
+namespace DogrudanTeminParadiseAPI.Dto
+{
+    public class UpdateOSAdditionalInspectionAcceptanceCertificateDto
+    {
+        public Guid AdministrationUnitId { get; set; }
+        public Guid SubAdministrationUnitId { get; set; }
+        public Guid ThreeSubAdministrationUnitId { get; set; }
+        public List<SelectedOfferItem> SelectedProducts { get; set; } = new();
+        public Guid SelectedOfferLetterId { get; set; }
+        public DateTime InvoiceDate { get; set; }
+        public string InvoiceNumber { get; set; }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Dto/UpdateOSInspectionAcceptanceCertificateDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/UpdateOSInspectionAcceptanceCertificateDto.cs
@@ -1,0 +1,15 @@
+using DogrudanTeminParadiseAPI.Helpers;
+
+namespace DogrudanTeminParadiseAPI.Dto
+{
+    public class UpdateOSInspectionAcceptanceCertificateDto
+    {
+        public string InvoiceNumber { get; set; }
+        public DateTime InvoiceDate { get; set; }
+        public List<SelectedOfferItem> SelectedProducts { get; set; } = new();
+        public Guid SelectedOfferLetterId { get; set; }
+        public Guid AdministrationUnitId { get; set; }
+        public Guid SubAdministrationUnitId { get; set; }
+        public Guid ThreeSubAdministrationUnitId { get; set; }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Dto/UpdateOSInspectionAcceptanceNoteDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/UpdateOSInspectionAcceptanceNoteDto.cs
@@ -1,0 +1,7 @@
+namespace DogrudanTeminParadiseAPI.Dto
+{
+    public class UpdateOSInspectionAcceptanceNoteDto
+    {
+        public string Note { get; set; }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Dto/UpdateOSMarketResearchJuryDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/UpdateOSMarketResearchJuryDto.cs
@@ -1,0 +1,7 @@
+namespace DogrudanTeminParadiseAPI.Dto
+{
+    public class UpdateOSMarketResearchJuryDto
+    {
+        public List<Guid> UserIds { get; set; } = new();
+    }
+}

--- a/DogrudanTeminParadiseAPI/Dto/UpdateOSOfferItemsByEntryDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/UpdateOSOfferItemsByEntryDto.cs
@@ -1,0 +1,8 @@
+namespace DogrudanTeminParadiseAPI.Dto
+{
+    public class UpdateOSOfferItemsByEntryDto
+    {
+        public Guid OneSourceProcurementEntryId { get; set; }
+        public List<OfferItemPriceUpdateDto> Items { get; set; } = new();
+    }
+}

--- a/DogrudanTeminParadiseAPI/Dto/UpdateOSOfferLetterDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/UpdateOSOfferLetterDto.cs
@@ -1,0 +1,12 @@
+using DogrudanTeminParadiseAPI.Helpers;
+
+namespace DogrudanTeminParadiseAPI.Dto
+{
+    public class UpdateOSOfferLetterDto
+    {
+        public List<UpdateOfferItemDto> OfferItems { get; set; } = new();
+        public string NotificationAddress { get; set; }
+        public string Email { get; set; }
+        public string Nationality { get; set; }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Dto/UpdateOSProcurementEntryDocumentsDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/UpdateOSProcurementEntryDocumentsDto.cs
@@ -1,0 +1,7 @@
+namespace DogrudanTeminParadiseAPI.Dto
+{
+    public class UpdateOSProcurementEntryDocumentsDto
+    {
+        public List<byte[]> EntrepriseFiles { get; set; } = new();
+    }
+}

--- a/DogrudanTeminParadiseAPI/Dto/UpdateOSProcurementEntryDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/UpdateOSProcurementEntryDto.cs
@@ -1,0 +1,32 @@
+using DogrudanTeminParadiseAPI.Helpers;
+
+namespace DogrudanTeminParadiseAPI.Dto
+{
+    public class UpdateOSProcurementEntryDto
+    {
+        public DateTime? ProcurementDecisionDate { get; set; }
+        public string? ProcurementDecisionNumber { get; set; }
+        public Guid? TenderResponsibleUserId { get; set; }
+        public string? TenderResponsibleTitle { get; set; }
+        public string? WorkName { get; set; }
+        public string? WorkReason { get; set; }
+        public Guid? BudgetAllocationId { get; set; }
+        public bool SpecificationToBePrepared { get; set; }
+        public bool ContractToBePrepared { get; set; }
+        public DateTime? PiyasaArastirmaOnayDate { get; set; }
+        public string? PiyasaArastirmaOnayNumber { get; set; }
+        public DateTime? TeklifMektubuDate { get; set; }
+        public string? TeklifMektubuNumber { get; set; }
+        public DateTime? PiyasaArastirmaBaslangicDate { get; set; }
+        public string? PiyasaArastirmaBaslangicNumber { get; set; }
+        public DateTime? YaklasikMaliyetHesaplamaBaslangicDate { get; set; }
+        public string? YaklasikMaliyetHesaplamaBaslangicNumber { get; set; }
+        public DateTime? MuayeneVeKabulBelgesiDate { get; set; }
+        public string? MuayeneVeKabulBelgesiNumber { get; set; }
+        public Guid? AdministrationUnitId { get; set; }
+        public Guid? SubAdministrationUnitId { get; set; }
+        public Guid? ThreeSubAdministrationUnitId { get; set; }
+        public KanunMaddesi KanunMaddesi { get; set; }
+        public List<string> TekKaynakTeminNedenleri { get; set; } = new();
+    }
+}

--- a/DogrudanTeminParadiseAPI/Dto/UpdateOSProcurementEntryEditorDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/UpdateOSProcurementEntryEditorDto.cs
@@ -1,0 +1,8 @@
+namespace DogrudanTeminParadiseAPI.Dto
+{
+    public class UpdateOSProcurementEntryEditorDto
+    {
+        public Guid OneSourceProcurementEntryId { get; set; }
+        public List<CreateOfferItemDto> OfferItems { get; set; } = new();
+    }
+}

--- a/DogrudanTeminParadiseAPI/Helpers/HelperClasses.cs
+++ b/DogrudanTeminParadiseAPI/Helpers/HelperClasses.cs
@@ -68,4 +68,11 @@ namespace DogrudanTeminParadiseAPI.Helpers
         PRODUCT,
         SERVICE
     }
+
+    public enum KanunMaddesi
+    {
+        _22A,
+        _22B,
+        _22C
+    }
 }

--- a/DogrudanTeminParadiseAPI/Mapping/MappingProfile.cs
+++ b/DogrudanTeminParadiseAPI/Mapping/MappingProfile.cs
@@ -56,8 +56,14 @@ namespace DogrudanTeminParadiseAPI.Mapping
             CreateMap<CreateOfferLetterDto, OfferLetter>();
             CreateMap<OfferLetter, OfferLetterDto>();
 
+            CreateMap<CreateOSOfferLetterDto, OSOfferLetter>();
+            CreateMap<OSOfferLetter, OSOfferLetterDto>();
+
             CreateMap<UpdateOfferLetterDto, OfferLetter>();
             CreateMap<OfferLetter, OfferLetterDto>();
+
+            CreateMap<UpdateOSOfferLetterDto, OSOfferLetter>();
+            CreateMap<OSOfferLetter, OSOfferLetterDto>();
 
             CreateMap<CreateCategoryDto, Category>();
             CreateMap<UpdateCategoryDto, Category>();
@@ -72,6 +78,9 @@ namespace DogrudanTeminParadiseAPI.Mapping
             CreateMap<CreateMarketResearchJuryDto, MarketResearchJury>();
             CreateMap<MarketResearchJury, MarketResearchJuryDto>();
             CreateMap<UpdateMarketResearchJuryDto, MarketResearchJury>();
+            CreateMap<CreateOSMarketResearchJuryDto, OSMarketResearchJury>();
+            CreateMap<OSMarketResearchJury, OSMarketResearchJuryDto>();
+            CreateMap<UpdateOSMarketResearchJuryDto, OSMarketResearchJury>();
 
             CreateMap<CreateApproximateCostJuryDto, ApproximateCostJury>();
             CreateMap<ApproximateCostJury, ApproximateCostJuryDto>();
@@ -85,9 +94,17 @@ namespace DogrudanTeminParadiseAPI.Mapping
             CreateMap<UpdateInspectionAcceptanceCertificateDto, InspectionAcceptanceCertificate>();
             CreateMap<InspectionAcceptanceCertificate, InspectionAcceptanceCertificateDto>();
 
+            CreateMap<CreateOSInspectionAcceptanceCertificateDto, OSInspectionAcceptanceCertificate>();
+            CreateMap<UpdateOSInspectionAcceptanceCertificateDto, OSInspectionAcceptanceCertificate>();
+            CreateMap<OSInspectionAcceptanceCertificate, OSInspectionAcceptanceCertificateDto>();
+
             CreateMap<CreateAdditionalInspectionAcceptanceCertificateDto, AdditionalInspectionAcceptanceCertificate>();
             CreateMap<UpdateAdditionalInspectionAcceptanceCertificateDto, AdditionalInspectionAcceptanceCertificate>();
             CreateMap<AdditionalInspectionAcceptanceCertificate, AdditionalInspectionAcceptanceCertificateDto>();
+
+            CreateMap<CreateOSAdditionalInspectionAcceptanceCertificateDto, OSAdditionalInspectionAcceptanceCertificate>();
+            CreateMap<UpdateOSAdditionalInspectionAcceptanceCertificateDto, OSAdditionalInspectionAcceptanceCertificate>();
+            CreateMap<OSAdditionalInspectionAcceptanceCertificate, OSAdditionalInspectionAcceptanceCertificateDto>();
 
             // Backup mappings
             CreateMap<CreateBackupInspectionAcceptanceCertificateDto, BackupInspectionAcceptanceCertificate>();
@@ -143,6 +160,13 @@ namespace DogrudanTeminParadiseAPI.Mapping
                 .ForMember(dest => dest.Id, opt => opt.MapFrom(src => Guid.Parse(src.Id)))
                 .ForMember(dest => dest.ProcurementEntryId, opt => opt.MapFrom(src => Guid.Parse(src.ProcurementEntryId)));
 
+            CreateMap<CreateOSInspectionAcceptanceNoteDto, OSInspectionAcceptanceNote>()
+                .ForMember(dest => dest.Id, opt => opt.Ignore());
+            CreateMap<UpdateOSInspectionAcceptanceNoteDto, OSInspectionAcceptanceNote>()
+                .ForMember(dest => dest.Id, opt => opt.Ignore())
+                .ForMember(dest => dest.OneSourceProcurementEntryId, opt => opt.Ignore());
+            CreateMap<OSInspectionAcceptanceNote, OSInspectionAcceptanceNoteDto>();
+
             CreateMap<CreateUserOwnFeaturesListDto, UserOwnFeaturesList>()
             .ForMember(dest => dest.Id, opt => opt.Ignore())
             .ForMember(dest => dest.UserId, opt => opt.MapFrom(src => src.UserId.ToString()));
@@ -183,6 +207,18 @@ namespace DogrudanTeminParadiseAPI.Mapping
             CreateMap<BudgetItem, BudgetItemCountDto>();
             CreateMap<BudgetItem, BudgetItemPaymentDto>();
             CreateMap<BudgetItem, BudgetItemOfferStatDto>();
+
+            CreateMap<CreateOSProcurementEntryDto, OSProcurementEntry>();
+            CreateMap<UpdateOSProcurementEntryDto, OSProcurementEntry>();
+            CreateMap<OSProcurementEntry, OSProcurementEntryDto>();
+
+            CreateMap<CreateOSProcurementEntryEditorDto, OSProcurementEntryEditor>();
+            CreateMap<UpdateOSProcurementEntryEditorDto, OSProcurementEntryEditor>();
+            CreateMap<OSProcurementEntryEditor, OSProcurementEntryEditorDto>();
+
+            CreateMap<CreateOSProcurementEntryDocumentsDto, OSProcurementEntryDocuments>();
+            CreateMap<UpdateOSProcurementEntryDocumentsDto, OSProcurementEntryDocuments>();
+            CreateMap<OSProcurementEntryDocuments, OSProcurementEntryDocumentsDto>();
         }
     }
 }

--- a/DogrudanTeminParadiseAPI/Models/OSAdditionalInspectionAcceptanceCertificate.cs
+++ b/DogrudanTeminParadiseAPI/Models/OSAdditionalInspectionAcceptanceCertificate.cs
@@ -1,0 +1,29 @@
+using DogrudanTeminParadiseAPI.Helpers;
+using DogrudanTeminParadiseAPI.Dto;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace DogrudanTeminParadiseAPI.Models
+{
+    public class OSAdditionalInspectionAcceptanceCertificate
+    {
+        [BsonId]
+        [BsonRepresentation(BsonType.String)]
+        public Guid Id { get; set; }
+
+        [BsonRepresentation(BsonType.String)]
+        public Guid OneSourceProcurementEntryId { get; set; }
+
+        [BsonRepresentation(BsonType.String)]
+        public Guid AdministrationUnitId { get; set; }
+        [BsonRepresentation(BsonType.String)]
+        public Guid SubAdministrationUnitId { get; set; }
+        [BsonRepresentation(BsonType.String)]
+        public Guid ThreeSubAdministrationUnitId { get; set; }
+        public List<SelectedOfferItem> SelectedProducts { get; set; } = new();
+        [BsonRepresentation(BsonType.String)]
+        public Guid SelectedOfferLetterId { get; set; }
+        public DateTime InvoiceDate { get; set; }
+        public string InvoiceNumber { get; set; }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Models/OSInspectionAcceptanceCertificate.cs
+++ b/DogrudanTeminParadiseAPI/Models/OSInspectionAcceptanceCertificate.cs
@@ -1,0 +1,31 @@
+using DogrudanTeminParadiseAPI.Dto;
+using DogrudanTeminParadiseAPI.Helpers;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace DogrudanTeminParadiseAPI.Models
+{
+    public class OSInspectionAcceptanceCertificate
+    {
+        [BsonId]
+        [BsonRepresentation(BsonType.String)]
+        public Guid Id { get; set; }
+
+        [BsonRepresentation(BsonType.String)]
+        public Guid OneSourceProcurementEntryId { get; set; }
+
+        public string InvoiceNumber { get; set; }
+        public DateTime InvoiceDate { get; set; }
+
+        public List<SelectedOfferItem> SelectedProducts { get; set; } = new();
+
+        [BsonRepresentation(BsonType.String)]
+        public Guid AdministrationUnitId { get; set; }
+        [BsonRepresentation(BsonType.String)]
+        public Guid SubAdministrationUnitId { get; set; }
+        [BsonRepresentation(BsonType.String)]
+        public Guid ThreeSubAdministrationUnitId { get; set; }
+        [BsonRepresentation(BsonType.String)]
+        public Guid SelectedOfferLetterId { get; set; }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Models/OSInspectionAcceptanceJury.cs
+++ b/DogrudanTeminParadiseAPI/Models/OSInspectionAcceptanceJury.cs
@@ -1,0 +1,24 @@
+using DogrudanTeminParadiseAPI.Helpers;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace DogrudanTeminParadiseAPI.Models
+{
+    public class OSInspectionAcceptanceJury
+    {
+        [BsonId]
+        [BsonRepresentation(BsonType.String)]
+        public Guid Id { get; set; }
+
+        [BsonRepresentation(BsonType.String)]
+        public Guid OneSourceProcurementEntryId { get; set; }
+
+        [BsonRepresentation(BsonType.String)]
+        public Guid InspectionAcceptanceJuryId { get; set; }
+
+        public JuryType Type { get; set; } = JuryType.INSPECTION_ACCEPTANCE;
+
+        [BsonRepresentation(BsonType.String)]
+        public List<Guid> UserIds { get; set; } = new();
+    }
+}

--- a/DogrudanTeminParadiseAPI/Models/OSInspectionAcceptanceNote.cs
+++ b/DogrudanTeminParadiseAPI/Models/OSInspectionAcceptanceNote.cs
@@ -1,0 +1,16 @@
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace DogrudanTeminParadiseAPI.Models
+{
+    public class OSInspectionAcceptanceNote
+    {
+        [BsonId]
+        [BsonRepresentation(BsonType.String)]
+        public Guid Id { get; set; }
+
+        [BsonRepresentation(BsonType.String)]
+        public Guid OneSourceProcurementEntryId { get; set; }
+        public string Note { get; set; }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Models/OSMarketResearchJury.cs
+++ b/DogrudanTeminParadiseAPI/Models/OSMarketResearchJury.cs
@@ -1,0 +1,22 @@
+using DogrudanTeminParadiseAPI.Helpers;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace DogrudanTeminParadiseAPI.Models
+{
+    public class OSMarketResearchJury
+    {
+        [BsonId]
+        [BsonRepresentation(BsonType.String)]
+        public Guid Id { get; set; }
+
+        [BsonRepresentation(BsonType.String)]
+        public Guid OneSourceProcurementEntryId { get; set; }
+
+        [BsonRepresentation(BsonType.String)]
+        public JuryType Type { get; set; } = JuryType.MARKET_RESEARCH;
+
+        [BsonRepresentation(BsonType.String)]
+        public List<Guid> UserIds { get; set; } = new();
+    }
+}

--- a/DogrudanTeminParadiseAPI/Models/OSOfferLetter.cs
+++ b/DogrudanTeminParadiseAPI/Models/OSOfferLetter.cs
@@ -1,0 +1,26 @@
+using DogrudanTeminParadiseAPI.Helpers;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace DogrudanTeminParadiseAPI.Models
+{
+    public class OSOfferLetter
+    {
+        [BsonId]
+        [BsonRepresentation(BsonType.String)]
+        public Guid Id { get; set; }
+
+        [BsonRepresentation(BsonType.String)]
+        public Guid EntrepriseId { get; set; }
+
+        [BsonRepresentation(BsonType.String)]
+        public Guid OneSourceProcurementEntryId { get; set; }
+
+        public List<OfferItem> OfferItems { get; set; } = new();
+        public string ResponsiblePerson { get; set; }
+        public string Vkn { get; set; }
+        public string NotificationAddress { get; set; }
+        public string Email { get; set; }
+        public string Nationality { get; set; }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Models/OSProcurementEntry.cs
+++ b/DogrudanTeminParadiseAPI/Models/OSProcurementEntry.cs
@@ -1,0 +1,52 @@
+using DogrudanTeminParadiseAPI.Helpers;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace DogrudanTeminParadiseAPI.Models
+{
+    public class OSProcurementEntry
+    {
+        [BsonId]
+        [BsonRepresentation(BsonType.String)]
+        public Guid Id { get; set; }
+
+        public DateTime? ProcurementDecisionDate { get; set; }
+        public string? ProcurementDecisionNumber { get; set; }
+
+        [BsonRepresentation(BsonType.String)]
+        public Guid? TenderResponsibleUserId { get; set; }
+        public string? TenderResponsibleTitle { get; set; }
+
+        public string? WorkName { get; set; }
+        public string? WorkReason { get; set; }
+        [BsonRepresentation(BsonType.String)]
+        public Guid? BudgetAllocationId { get; set; }
+        public bool SpecificationToBePrepared { get; set; }
+        public bool ContractToBePrepared { get; set; }
+
+        public DateTime? PiyasaArastirmaOnayDate { get; set; }
+        public string? PiyasaArastirmaOnayNumber { get; set; }
+
+        public DateTime? TeklifMektubuDate { get; set; }
+        public string? TeklifMektubuNumber { get; set; }
+
+        public DateTime? PiyasaArastirmaBaslangicDate { get; set; }
+        public string? PiyasaArastirmaBaslangicNumber { get; set; }
+
+        public DateTime? YaklasikMaliyetHesaplamaBaslangicDate { get; set; }
+        public string? YaklasikMaliyetHesaplamaBaslangicNumber { get; set; }
+
+        public DateTime? MuayeneVeKabulBelgesiDate { get; set; }
+        public string? MuayeneVeKabulBelgesiNumber { get; set; }
+
+        [BsonRepresentation(BsonType.String)]
+        public Guid? AdministrationUnitId { get; set; }
+        [BsonRepresentation(BsonType.String)]
+        public Guid? SubAdministrationUnitId { get; set; }
+        [BsonRepresentation(BsonType.String)]
+        public Guid? ThreeSubAdministrationUnitId { get; set; }
+
+        public KanunMaddesi KanunMaddesi { get; set; }
+        public List<string> TekKaynakTeminNedenleri { get; set; } = new();
+    }
+}

--- a/DogrudanTeminParadiseAPI/Models/OSProcurementEntryDocuments.cs
+++ b/DogrudanTeminParadiseAPI/Models/OSProcurementEntryDocuments.cs
@@ -1,0 +1,19 @@
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace DogrudanTeminParadiseAPI.Models
+{
+    public class OSProcurementEntryDocuments
+    {
+        [BsonId]
+        [BsonRepresentation(BsonType.String)]
+        public Guid Id { get; set; }
+
+        [BsonRepresentation(BsonType.String)]
+        public Guid OneSourceProcurementEntryId { get; set; }
+
+        public List<string> EntrepriseFileIds { get; set; } = new();
+
+        public DateTime TransactionAt { get; set; }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Models/OSProcurementEntryEditor.cs
+++ b/DogrudanTeminParadiseAPI/Models/OSProcurementEntryEditor.cs
@@ -1,0 +1,17 @@
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace DogrudanTeminParadiseAPI.Models
+{
+    public class OSProcurementEntryEditor
+    {
+        [BsonId]
+        [BsonRepresentation(BsonType.String)]
+        public Guid Id { get; set; }
+
+        [BsonRepresentation(BsonType.String)]
+        public Guid OneSourceProcurementEntryId { get; set; }
+
+        public List<OfferItem> OfferItems { get; set; } = new();
+    }
+}

--- a/DogrudanTeminParadiseAPI/Models/OneSourceProcurementEntry.cs
+++ b/DogrudanTeminParadiseAPI/Models/OneSourceProcurementEntry.cs
@@ -1,0 +1,52 @@
+using DogrudanTeminParadiseAPI.Helpers;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace DogrudanTeminParadiseAPI.Models
+{
+    public class OneSourceProcurementEntry
+    {
+        [BsonId]
+        [BsonRepresentation(BsonType.String)]
+        public Guid Id { get; set; }
+
+        public DateTime? ProcurementDecisionDate { get; set; }
+        public string? ProcurementDecisionNumber { get; set; }
+
+        [BsonRepresentation(BsonType.String)]
+        public Guid? TenderResponsibleUserId { get; set; }
+        public string? TenderResponsibleTitle { get; set; }
+
+        public string? WorkName { get; set; }
+        public string? WorkReason { get; set; }
+        [BsonRepresentation(BsonType.String)]
+        public Guid? BudgetAllocationId { get; set; }
+        public bool SpecificationToBePrepared { get; set; }
+        public bool ContractToBePrepared { get; set; }
+
+        public DateTime? PiyasaArastirmaOnayDate { get; set; }
+        public string? PiyasaArastirmaOnayNumber { get; set; }
+
+        public DateTime? TeklifMektubuDate { get; set; }
+        public string? TeklifMektubuNumber { get; set; }
+
+        public DateTime? PiyasaArastirmaBaslangicDate { get; set; }
+        public string? PiyasaArastirmaBaslangicNumber { get; set; }
+
+        public DateTime? YaklasikMaliyetHesaplamaBaslangicDate { get; set; }
+        public string? YaklasikMaliyetHesaplamaBaslangicNumber { get; set; }
+
+        public DateTime? MuayeneVeKabulBelgesiDate { get; set; }
+        public string? MuayeneVeKabulBelgesiNumber { get; set; }
+
+        [BsonRepresentation(BsonType.String)]
+        public Guid? AdministrationUnitId { get; set; }
+        [BsonRepresentation(BsonType.String)]
+        public Guid? SubAdministrationUnitId { get; set; }
+        [BsonRepresentation(BsonType.String)]
+        public Guid? ThreeSubAdministrationUnitId { get; set; }
+
+        public KanunMaddesi KanunMaddesi { get; set; }
+        public List<string> TekKaynakTeminNedenleri { get; set; } = new();
+    }
+}

--- a/DogrudanTeminParadiseAPI/Program.cs
+++ b/DogrudanTeminParadiseAPI/Program.cs
@@ -86,6 +86,14 @@ builder.Services.AddScoped(sp => new MongoDBRepository<SharedProcurementEntry>(c
 builder.Services.AddScoped(sp => new MongoDBRepository<UserNotification>(cfg["MongoAPI"], cfg["MongoDBName"], "UserNotifications"));
 builder.Services.AddScoped(sp => new MongoDBRepository<BackupUserNotification>(cfg["MongoAPI"], cfg["MongoBackupDBName"], "BackupUserNotifications"));
 builder.Services.AddScoped(sp => new MongoDBRepository<Notification>(cfg["MongoAPI"], cfg["MongoDBName"], "Notifications"));
+builder.Services.AddScoped(sp => new MongoDBRepository<OSProcurementEntryDocuments>(cfg["MongoAPI"], cfg["MongoDBName"], "OSProcurementEntryDocuments"));
+builder.Services.AddScoped(sp => new MongoDBRepository<OSProcurementEntry>(cfg["MongoAPI"], cfg["MongoDBName"], "OSProcurementEntries"));
+builder.Services.AddScoped(sp => new MongoDBRepository<OSProcurementEntryEditor>(cfg["MongoAPI"], cfg["MongoDBName"], "OSProcurementEntryEditors"));
+builder.Services.AddScoped(sp => new MongoDBRepository<OSOfferLetter>(cfg["MongoAPI"], cfg["MongoDBName"], "OSOfferLetters"));
+builder.Services.AddScoped(sp => new MongoDBRepository<OSMarketResearchJury>(cfg["MongoAPI"], cfg["MongoDBName"], "OSMarketResearchJuries"));
+builder.Services.AddScoped(sp => new MongoDBRepository<OSInspectionAcceptanceNote>(cfg["MongoAPI"], cfg["MongoDBName"], "OSInspectionAcceptanceNotes"));
+builder.Services.AddScoped(sp => new MongoDBRepository<OSInspectionAcceptanceCertificate>(cfg["MongoAPI"], cfg["MongoDBName"], "OSInspectionAcceptanceCertificates"));
+builder.Services.AddScoped(sp => new MongoDBRepository<OSAdditionalInspectionAcceptanceCertificate>(cfg["MongoAPI"], cfg["MongoDBName"], "OSAdditionalInspectionAcceptanceCertificates"));
 
 builder.Services.AddSingleton<IMongoClient>(sp =>
     new MongoClient(cfg["MongoAPI"])
@@ -96,6 +104,7 @@ builder.Services.AddScoped(sp =>
     var client = sp.GetRequiredService<IMongoClient>();
     return client.GetDatabase(cfg["MongoDBName"]);
 });
+builder.Services.AddScoped(sp => new GridFSRepository(cfg["MongoAPI"], cfg["MongoDBName"]));
 
 // Servisler
 
@@ -140,6 +149,14 @@ builder.Services.AddScoped<ISharedProcurementEntryService, SharedProcurementEntr
 builder.Services.AddScoped<IUserNotificationService, UserNotificationService>();
 builder.Services.AddScoped<IBackupUserNotificationService, BackupUserNotificationService>();
 builder.Services.AddScoped<INotificationService, NotificationService>();
+builder.Services.AddScoped<IOSProcurementEntryDocumentsService, OSProcurementEntryDocumentsService>();
+builder.Services.AddScoped<IOSProcurementEntryService, OSProcurementEntryService>();
+builder.Services.AddScoped<IOSProcurementEntryEditorService, OSProcurementEntryEditorService>();
+builder.Services.AddScoped<IOSOfferLetterService, OSOfferLetterService>();
+builder.Services.AddScoped<IOSMarketResearchJuryService, OSMarketResearchJuryService>();
+builder.Services.AddScoped<IOSInspectionAcceptanceNoteService, OSInspectionAcceptanceNoteService>();
+builder.Services.AddScoped<IOSInspectionAcceptanceCertificateService, OSInspectionAcceptanceCertificateService>();
+builder.Services.AddScoped<IOSAdditionalInspectionAcceptanceService, OSAdditionalInspectionAcceptanceService>();
 // Factoryler
 builder.Services.AddSingleton<ITeminApiExceptionFactory, TeminApiExceptionFactory>();
 

--- a/DogrudanTeminParadiseAPI/Repositories/GridFSRepository.cs
+++ b/DogrudanTeminParadiseAPI/Repositories/GridFSRepository.cs
@@ -1,0 +1,34 @@
+using MongoDB.Bson;
+using MongoDB.Driver;
+using MongoDB.Driver.GridFS;
+
+namespace DogrudanTeminParadiseAPI.Repositories
+{
+    public class GridFSRepository
+    {
+        private readonly GridFSBucket _bucket;
+
+        public GridFSRepository(string connectionString, string dbName)
+        {
+            var client = new MongoClient(connectionString);
+            var db = client.GetDatabase(dbName);
+            _bucket = new GridFSBucket(db);
+        }
+
+        public async Task<string> UploadAsync(byte[] data, string fileName)
+        {
+            var id = await _bucket.UploadFromBytesAsync(fileName, data);
+            return id.ToString();
+        }
+
+        public async Task<byte[]> DownloadAsync(string id)
+        {
+            return await _bucket.DownloadAsBytesAsync(ObjectId.Parse(id));
+        }
+
+        public async Task DeleteAsync(string id)
+        {
+            await _bucket.DeleteAsync(ObjectId.Parse(id));
+        }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Service/Abstract/IOSAdditionalInspectionAcceptanceService.cs
+++ b/DogrudanTeminParadiseAPI/Service/Abstract/IOSAdditionalInspectionAcceptanceService.cs
@@ -1,0 +1,16 @@
+using DogrudanTeminParadiseAPI.Dto;
+
+namespace DogrudanTeminParadiseAPI.Service.Abstract
+{
+    public interface IOSAdditionalInspectionAcceptanceService
+    {
+        Task<OSAdditionalInspectionAcceptanceCertificateDto> CreateAsync(CreateOSAdditionalInspectionAcceptanceCertificateDto dto);
+        Task<IEnumerable<OSAdditionalInspectionAcceptanceCertificateDto>> GetAllAsync();
+        Task<IEnumerable<OSAdditionalInspectionAcceptanceCertificateDto>> GetAllAsync(IEnumerable<Guid> permittedEntryIds);
+        Task<IEnumerable<OSAdditionalInspectionAcceptanceCertificateDto>> GetAllByEntryAsync(Guid entryId);
+        Task<IEnumerable<OSAdditionalInspectionAcceptanceCertificateDto>> GetAllByEntryAsync(Guid entryId, IEnumerable<Guid> permittedEntryIds);
+        Task<OSAdditionalInspectionAcceptanceCertificateDto?> GetByIdAsync(Guid id);
+        Task<OSAdditionalInspectionAcceptanceCertificateDto?> UpdateAsync(Guid id, UpdateOSAdditionalInspectionAcceptanceCertificateDto dto);
+        Task DeleteAsync(Guid id, Guid userId);
+    }
+}

--- a/DogrudanTeminParadiseAPI/Service/Abstract/IOSInspectionAcceptanceCertificateService.cs
+++ b/DogrudanTeminParadiseAPI/Service/Abstract/IOSInspectionAcceptanceCertificateService.cs
@@ -1,0 +1,16 @@
+using DogrudanTeminParadiseAPI.Dto;
+
+namespace DogrudanTeminParadiseAPI.Service.Abstract
+{
+    public interface IOSInspectionAcceptanceCertificateService
+    {
+        Task<OSInspectionAcceptanceCertificateDto> CreateAsync(CreateOSInspectionAcceptanceCertificateDto dto);
+        Task<IEnumerable<OSInspectionAcceptanceCertificateDto>> GetAllAsync();
+        Task<IEnumerable<OSInspectionAcceptanceCertificateDto>> GetAllAsync(IEnumerable<Guid> permittedEntryIds);
+        Task<IEnumerable<OSInspectionAcceptanceCertificateDto>> GetAllByEntryAsync(Guid entryId);
+        Task<IEnumerable<OSInspectionAcceptanceCertificateDto>> GetAllByEntryAsync(Guid entryId, IEnumerable<Guid> permittedEntryIds);
+        Task<OSInspectionAcceptanceCertificateDto?> GetByIdAsync(Guid id);
+        Task<OSInspectionAcceptanceCertificateDto?> UpdateAsync(Guid id, UpdateOSInspectionAcceptanceCertificateDto dto);
+        Task DeleteAsync(Guid id, Guid userId);
+    }
+}

--- a/DogrudanTeminParadiseAPI/Service/Abstract/IOSInspectionAcceptanceNoteService.cs
+++ b/DogrudanTeminParadiseAPI/Service/Abstract/IOSInspectionAcceptanceNoteService.cs
@@ -1,0 +1,13 @@
+using DogrudanTeminParadiseAPI.Dto;
+
+namespace DogrudanTeminParadiseAPI.Service.Abstract
+{
+    public interface IOSInspectionAcceptanceNoteService
+    {
+        Task<OSInspectionAcceptanceNoteDto> CreateAsync(CreateOSInspectionAcceptanceNoteDto dto);
+        Task<IEnumerable<OSInspectionAcceptanceNoteDto>> GetAllByEntryAsync(Guid entryId);
+        Task<OSInspectionAcceptanceNoteDto?> GetByIdAsync(Guid id);
+        Task<OSInspectionAcceptanceNoteDto?> UpdateAsync(Guid id, UpdateOSInspectionAcceptanceNoteDto dto);
+        Task DeleteAsync(Guid id);
+    }
+}

--- a/DogrudanTeminParadiseAPI/Service/Abstract/IOSMarketResearchJuryService.cs
+++ b/DogrudanTeminParadiseAPI/Service/Abstract/IOSMarketResearchJuryService.cs
@@ -1,0 +1,13 @@
+using DogrudanTeminParadiseAPI.Dto;
+
+namespace DogrudanTeminParadiseAPI.Service.Abstract
+{
+    public interface IOSMarketResearchJuryService
+    {
+        Task<OSMarketResearchJuryDto> CreateAsync(CreateOSMarketResearchJuryDto dto);
+        Task<IEnumerable<OSMarketResearchJuryDto>> GetAllByEntryAsync(Guid entryId);
+        Task<OSMarketResearchJuryDto?> GetByIdAsync(Guid id);
+        Task<OSMarketResearchJuryDto?> UpdateAsync(Guid id, UpdateOSMarketResearchJuryDto dto);
+        Task DeleteAsync(Guid id);
+    }
+}

--- a/DogrudanTeminParadiseAPI/Service/Abstract/IOSOfferLetterService.cs
+++ b/DogrudanTeminParadiseAPI/Service/Abstract/IOSOfferLetterService.cs
@@ -1,0 +1,17 @@
+using DogrudanTeminParadiseAPI.Dto;
+
+namespace DogrudanTeminParadiseAPI.Service.Abstract
+{
+    public interface IOSOfferLetterService
+    {
+        Task<OSOfferLetterDto> CreateAsync(CreateOSOfferLetterDto dto);
+        Task<IEnumerable<OSOfferLetterDto>> GetAllAsync();
+        Task<IEnumerable<OSOfferLetterDto>> GetAllAsync(IEnumerable<Guid> permittedEntryIds);
+        Task<IEnumerable<OSOfferLetterDto>> GetAllByEntryAsync(Guid entryId);
+        Task<IEnumerable<OSOfferLetterDto>> GetAllByEntryAsync(Guid entryId, IEnumerable<Guid> permittedEntryIds);
+        Task<IEnumerable<OSOfferLetterDto>> UpdateItemsByEntryAsync(Guid entryId, UpdateOSOfferItemsByEntryDto dto);
+        Task<OSOfferLetterDto> GetByIdAsync(Guid id);
+        Task<OSOfferLetterDto> UpdateAsync(Guid id, UpdateOSOfferLetterDto dto);
+        Task DeleteAsync(Guid id, Guid userId);
+    }
+}

--- a/DogrudanTeminParadiseAPI/Service/Abstract/IOSProcurementEntryDocumentsService.cs
+++ b/DogrudanTeminParadiseAPI/Service/Abstract/IOSProcurementEntryDocumentsService.cs
@@ -1,0 +1,13 @@
+using DogrudanTeminParadiseAPI.Dto;
+
+namespace DogrudanTeminParadiseAPI.Service.Abstract
+{
+    public interface IOSProcurementEntryDocumentsService
+    {
+        Task<OSProcurementEntryDocumentsDto> CreateAsync(CreateOSProcurementEntryDocumentsDto dto);
+        Task<IEnumerable<OSProcurementEntryDocumentsDto>> GetAllByEntryAsync(Guid entryId);
+        Task<OSProcurementEntryDocumentsDto> GetByIdAsync(Guid id);
+        Task<OSProcurementEntryDocumentsDto> UpdateAsync(Guid id, UpdateOSProcurementEntryDocumentsDto dto);
+        Task DeleteAsync(Guid id);
+    }
+}

--- a/DogrudanTeminParadiseAPI/Service/Abstract/IOSProcurementEntryEditorService.cs
+++ b/DogrudanTeminParadiseAPI/Service/Abstract/IOSProcurementEntryEditorService.cs
@@ -1,0 +1,13 @@
+using DogrudanTeminParadiseAPI.Dto;
+
+namespace DogrudanTeminParadiseAPI.Service.Abstract
+{
+    public interface IOSProcurementEntryEditorService
+    {
+        Task<OSProcurementEntryEditorDto> CreateAsync(CreateOSProcurementEntryEditorDto dto);
+        Task<OSProcurementEntryEditorDto> GetAsync();
+        Task<OSProcurementEntryEditorDto> GetByIdAsync(Guid id);
+        Task<OSProcurementEntryEditorDto> UpdateAsync(UpdateOSProcurementEntryEditorDto dto);
+        Task<OSProcurementEntryEditorDto> GetEditorByEntryIdAsync(Guid entryId);
+    }
+}

--- a/DogrudanTeminParadiseAPI/Service/Abstract/IOSProcurementEntryService.cs
+++ b/DogrudanTeminParadiseAPI/Service/Abstract/IOSProcurementEntryService.cs
@@ -1,0 +1,13 @@
+using DogrudanTeminParadiseAPI.Dto;
+
+namespace DogrudanTeminParadiseAPI.Service.Abstract
+{
+    public interface IOSProcurementEntryService
+    {
+        Task<OSProcurementEntryDto> CreateAsync(CreateOSProcurementEntryDto dto);
+        Task<IEnumerable<OSProcurementEntryDto>> GetAllAsync();
+        Task<OSProcurementEntryDto?> GetByIdAsync(Guid id);
+        Task<OSProcurementEntryDto?> UpdateAsync(Guid id, UpdateOSProcurementEntryDto dto);
+        Task DeleteAsync(Guid id);
+    }
+}

--- a/DogrudanTeminParadiseAPI/Service/Concrete/OSAdditionalInspectionAcceptanceService.cs
+++ b/DogrudanTeminParadiseAPI/Service/Concrete/OSAdditionalInspectionAcceptanceService.cs
@@ -1,0 +1,100 @@
+using AutoMapper;
+using DogrudanTeminParadiseAPI.Dto;
+using DogrudanTeminParadiseAPI.Helpers;
+using DogrudanTeminParadiseAPI.Models;
+using DogrudanTeminParadiseAPI.Repositories;
+using DogrudanTeminParadiseAPI.Service.Abstract;
+
+namespace DogrudanTeminParadiseAPI.Service.Concrete
+{
+    public class OSAdditionalInspectionAcceptanceService : IOSAdditionalInspectionAcceptanceService
+    {
+        private readonly MongoDBRepository<OSAdditionalInspectionAcceptanceCertificate> _repo;
+        private readonly IMapper _mapper;
+
+        public OSAdditionalInspectionAcceptanceService(
+            MongoDBRepository<OSAdditionalInspectionAcceptanceCertificate> repo,
+            IMapper mapper)
+        {
+            _repo = repo;
+            _mapper = mapper;
+        }
+
+        public async Task<OSAdditionalInspectionAcceptanceCertificateDto> CreateAsync(CreateOSAdditionalInspectionAcceptanceCertificateDto dto)
+        {
+            var entity = _mapper.Map<OSAdditionalInspectionAcceptanceCertificate>(dto);
+            entity.Id = Guid.NewGuid();
+            entity.SelectedProducts = dto.SelectedProducts.Select(i => new SelectedOfferItem
+            {
+                Id = Guid.NewGuid(),
+                Name = i.Name,
+                Features = i.Features,
+                Quantity = i.Quantity,
+                UnitId = i.UnitId,
+                UnitPrice = i.UnitPrice
+            }).ToList();
+            await _repo.InsertAsync(entity);
+            return _mapper.Map<OSAdditionalInspectionAcceptanceCertificateDto>(entity);
+        }
+
+        public async Task DeleteAsync(Guid id, Guid userId)
+        {
+            await _repo.DeleteAsync(id);
+        }
+
+        public async Task<IEnumerable<OSAdditionalInspectionAcceptanceCertificateDto>> GetAllAsync()
+        {
+            var list = await _repo.GetAllAsync();
+            return list.Select(_mapper.Map<OSAdditionalInspectionAcceptanceCertificateDto>);
+        }
+
+        public async Task<IEnumerable<OSAdditionalInspectionAcceptanceCertificateDto>> GetAllAsync(IEnumerable<Guid> permittedEntryIds)
+        {
+            if (permittedEntryIds == null)
+                return Enumerable.Empty<OSAdditionalInspectionAcceptanceCertificateDto>();
+            var list = await _repo.GetAllAsync();
+            return list.Where(e => permittedEntryIds.Contains(e.OneSourceProcurementEntryId))
+                       .Select(_mapper.Map<OSAdditionalInspectionAcceptanceCertificateDto>);
+        }
+
+        public async Task<IEnumerable<OSAdditionalInspectionAcceptanceCertificateDto>> GetAllByEntryAsync(Guid entryId)
+        {
+            var list = (await _repo.GetAllAsync())
+                .Where(e => e.OneSourceProcurementEntryId == entryId);
+            return list.Select(_mapper.Map<OSAdditionalInspectionAcceptanceCertificateDto>);
+        }
+
+        public async Task<IEnumerable<OSAdditionalInspectionAcceptanceCertificateDto>> GetAllByEntryAsync(Guid entryId, IEnumerable<Guid> permittedEntryIds)
+        {
+            if (permittedEntryIds == null || !permittedEntryIds.Contains(entryId))
+                return Enumerable.Empty<OSAdditionalInspectionAcceptanceCertificateDto>();
+            var list = await _repo.GetAllAsync();
+            return list.Where(e => e.OneSourceProcurementEntryId == entryId)
+                       .Select(_mapper.Map<OSAdditionalInspectionAcceptanceCertificateDto>);
+        }
+
+        public async Task<OSAdditionalInspectionAcceptanceCertificateDto?> GetByIdAsync(Guid id)
+        {
+            var e = await _repo.GetByIdAsync(id);
+            return e == null ? null : _mapper.Map<OSAdditionalInspectionAcceptanceCertificateDto>(e);
+        }
+
+        public async Task<OSAdditionalInspectionAcceptanceCertificateDto?> UpdateAsync(Guid id, UpdateOSAdditionalInspectionAcceptanceCertificateDto dto)
+        {
+            var existing = await _repo.GetByIdAsync(id);
+            if (existing == null) return null;
+            _mapper.Map(dto, existing);
+            existing.SelectedProducts = dto.SelectedProducts.Select(i => new SelectedOfferItem
+            {
+                Id = i.Id == Guid.Empty ? Guid.NewGuid() : i.Id,
+                Name = i.Name,
+                Features = i.Features,
+                Quantity = i.Quantity,
+                UnitId = i.UnitId,
+                UnitPrice = i.UnitPrice
+            }).ToList();
+            await _repo.UpdateAsync(id, existing);
+            return _mapper.Map<OSAdditionalInspectionAcceptanceCertificateDto>(existing);
+        }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Service/Concrete/OSInspectionAcceptanceCertificateService.cs
+++ b/DogrudanTeminParadiseAPI/Service/Concrete/OSInspectionAcceptanceCertificateService.cs
@@ -1,0 +1,100 @@
+using AutoMapper;
+using DogrudanTeminParadiseAPI.Dto;
+using DogrudanTeminParadiseAPI.Helpers;
+using DogrudanTeminParadiseAPI.Models;
+using DogrudanTeminParadiseAPI.Repositories;
+using DogrudanTeminParadiseAPI.Service.Abstract;
+
+namespace DogrudanTeminParadiseAPI.Service.Concrete
+{
+    public class OSInspectionAcceptanceCertificateService : IOSInspectionAcceptanceCertificateService
+    {
+        private readonly MongoDBRepository<OSInspectionAcceptanceCertificate> _repo;
+        private readonly IMapper _mapper;
+
+        public OSInspectionAcceptanceCertificateService(
+            MongoDBRepository<OSInspectionAcceptanceCertificate> repo,
+            IMapper mapper)
+        {
+            _repo = repo;
+            _mapper = mapper;
+        }
+
+        public async Task<OSInspectionAcceptanceCertificateDto> CreateAsync(CreateOSInspectionAcceptanceCertificateDto dto)
+        {
+            var entity = _mapper.Map<OSInspectionAcceptanceCertificate>(dto);
+            entity.Id = Guid.NewGuid();
+            entity.SelectedProducts = dto.SelectedProducts.Select(i => new SelectedOfferItem
+            {
+                Id = Guid.NewGuid(),
+                Name = i.Name,
+                Features = i.Features,
+                Quantity = i.Quantity,
+                UnitId = i.UnitId,
+                UnitPrice = i.UnitPrice
+            }).ToList();
+            await _repo.InsertAsync(entity);
+            return _mapper.Map<OSInspectionAcceptanceCertificateDto>(entity);
+        }
+
+        public async Task DeleteAsync(Guid id, Guid userId)
+        {
+            await _repo.DeleteAsync(id);
+        }
+
+        public async Task<IEnumerable<OSInspectionAcceptanceCertificateDto>> GetAllAsync()
+        {
+            var list = await _repo.GetAllAsync();
+            return list.Select(_mapper.Map<OSInspectionAcceptanceCertificateDto>);
+        }
+
+        public async Task<IEnumerable<OSInspectionAcceptanceCertificateDto>> GetAllAsync(IEnumerable<Guid> permittedEntryIds)
+        {
+            if (permittedEntryIds == null)
+                return Enumerable.Empty<OSInspectionAcceptanceCertificateDto>();
+            var list = await _repo.GetAllAsync();
+            return list.Where(e => permittedEntryIds.Contains(e.OneSourceProcurementEntryId))
+                       .Select(_mapper.Map<OSInspectionAcceptanceCertificateDto>);
+        }
+
+        public async Task<IEnumerable<OSInspectionAcceptanceCertificateDto>> GetAllByEntryAsync(Guid entryId)
+        {
+            var list = (await _repo.GetAllAsync())
+                .Where(e => e.OneSourceProcurementEntryId == entryId);
+            return list.Select(_mapper.Map<OSInspectionAcceptanceCertificateDto>);
+        }
+
+        public async Task<IEnumerable<OSInspectionAcceptanceCertificateDto>> GetAllByEntryAsync(Guid entryId, IEnumerable<Guid> permittedEntryIds)
+        {
+            if (permittedEntryIds == null || !permittedEntryIds.Contains(entryId))
+                return Enumerable.Empty<OSInspectionAcceptanceCertificateDto>();
+            var list = await _repo.GetAllAsync();
+            return list.Where(e => e.OneSourceProcurementEntryId == entryId)
+                       .Select(_mapper.Map<OSInspectionAcceptanceCertificateDto>);
+        }
+
+        public async Task<OSInspectionAcceptanceCertificateDto?> GetByIdAsync(Guid id)
+        {
+            var e = await _repo.GetByIdAsync(id);
+            return e == null ? null : _mapper.Map<OSInspectionAcceptanceCertificateDto>(e);
+        }
+
+        public async Task<OSInspectionAcceptanceCertificateDto?> UpdateAsync(Guid id, UpdateOSInspectionAcceptanceCertificateDto dto)
+        {
+            var existing = await _repo.GetByIdAsync(id);
+            if (existing == null) return null;
+            _mapper.Map(dto, existing);
+            existing.SelectedProducts = dto.SelectedProducts.Select(i => new SelectedOfferItem
+            {
+                Id = i.Id == Guid.Empty ? Guid.NewGuid() : i.Id,
+                Name = i.Name,
+                Features = i.Features,
+                Quantity = i.Quantity,
+                UnitId = i.UnitId,
+                UnitPrice = i.UnitPrice
+            }).ToList();
+            await _repo.UpdateAsync(id, existing);
+            return _mapper.Map<OSInspectionAcceptanceCertificateDto>(existing);
+        }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Service/Concrete/OSInspectionAcceptanceNoteService.cs
+++ b/DogrudanTeminParadiseAPI/Service/Concrete/OSInspectionAcceptanceNoteService.cs
@@ -1,0 +1,57 @@
+using AutoMapper;
+using DogrudanTeminParadiseAPI.Dto;
+using DogrudanTeminParadiseAPI.Models;
+using DogrudanTeminParadiseAPI.Repositories;
+using DogrudanTeminParadiseAPI.Service.Abstract;
+using MongoDB.Driver;
+
+namespace DogrudanTeminParadiseAPI.Service.Concrete
+{
+    public class OSInspectionAcceptanceNoteService : IOSInspectionAcceptanceNoteService
+    {
+        private readonly MongoDBRepository<OSInspectionAcceptanceNote> _repo;
+        private readonly IMapper _mapper;
+
+        public OSInspectionAcceptanceNoteService(MongoDBRepository<OSInspectionAcceptanceNote> repo, IMapper mapper)
+        {
+            _repo = repo;
+            _mapper = mapper;
+        }
+
+        public async Task<OSInspectionAcceptanceNoteDto> CreateAsync(CreateOSInspectionAcceptanceNoteDto dto)
+        {
+            var entity = _mapper.Map<OSInspectionAcceptanceNote>(dto);
+            entity.Id = Guid.NewGuid();
+            await _repo.InsertAsync(entity);
+            return _mapper.Map<OSInspectionAcceptanceNoteDto>(entity);
+        }
+
+        public async Task DeleteAsync(Guid id)
+        {
+            var existing = await _repo.GetByIdAsync(id) ?? throw new KeyNotFoundException("Note bulunamadı.");
+            await _repo.DeleteAsync(id);
+        }
+
+        public async Task<IEnumerable<OSInspectionAcceptanceNoteDto>> GetAllByEntryAsync(Guid entryId)
+        {
+            var filter = Builders<OSInspectionAcceptanceNote>.Filter.Eq(n => n.OneSourceProcurementEntryId, entryId);
+            var list = await _repo.GetAllAsync(filter);
+            return list.Select(_mapper.Map<OSInspectionAcceptanceNoteDto>);
+        }
+
+        public async Task<OSInspectionAcceptanceNoteDto?> GetByIdAsync(Guid id)
+        {
+            var e = await _repo.GetByIdAsync(id);
+            return e == null ? null : _mapper.Map<OSInspectionAcceptanceNoteDto>(e);
+        }
+
+        public async Task<OSInspectionAcceptanceNoteDto?> UpdateAsync(Guid id, UpdateOSInspectionAcceptanceNoteDto dto)
+        {
+            var existing = await _repo.GetByIdAsync(id);
+            if (existing == null) return null;
+            _mapper.Map(dto, existing);
+            await _repo.UpdateAsync(id, existing);
+            return _mapper.Map<OSInspectionAcceptanceNoteDto>(existing);
+        }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Service/Concrete/OSMarketResearchJuryService.cs
+++ b/DogrudanTeminParadiseAPI/Service/Concrete/OSMarketResearchJuryService.cs
@@ -1,0 +1,55 @@
+using AutoMapper;
+using DogrudanTeminParadiseAPI.Dto;
+using DogrudanTeminParadiseAPI.Models;
+using DogrudanTeminParadiseAPI.Repositories;
+using DogrudanTeminParadiseAPI.Service.Abstract;
+
+namespace DogrudanTeminParadiseAPI.Service.Concrete
+{
+    public class OSMarketResearchJuryService : IOSMarketResearchJuryService
+    {
+        private readonly MongoDBRepository<OSMarketResearchJury> _repo;
+        private readonly IMapper _mapper;
+
+        public OSMarketResearchJuryService(MongoDBRepository<OSMarketResearchJury> repo, IMapper mapper)
+        {
+            _repo = repo;
+            _mapper = mapper;
+        }
+
+        public async Task<OSMarketResearchJuryDto> CreateAsync(CreateOSMarketResearchJuryDto dto)
+        {
+            var entity = _mapper.Map<OSMarketResearchJury>(dto);
+            entity.Id = Guid.NewGuid();
+            await _repo.InsertAsync(entity);
+            return _mapper.Map<OSMarketResearchJuryDto>(entity);
+        }
+
+        public async Task DeleteAsync(Guid id)
+        {
+            await _repo.DeleteAsync(id);
+        }
+
+        public async Task<IEnumerable<OSMarketResearchJuryDto>> GetAllByEntryAsync(Guid entryId)
+        {
+            var list = (await _repo.GetAllAsync())
+                .Where(j => j.OneSourceProcurementEntryId == entryId);
+            return list.Select(_mapper.Map<OSMarketResearchJuryDto>);
+        }
+
+        public async Task<OSMarketResearchJuryDto?> GetByIdAsync(Guid id)
+        {
+            var e = await _repo.GetByIdAsync(id);
+            return e == null ? null : _mapper.Map<OSMarketResearchJuryDto>(e);
+        }
+
+        public async Task<OSMarketResearchJuryDto?> UpdateAsync(Guid id, UpdateOSMarketResearchJuryDto dto)
+        {
+            var existing = await _repo.GetByIdAsync(id);
+            if (existing == null) return null;
+            existing.UserIds = dto.UserIds;
+            await _repo.UpdateAsync(id, existing);
+            return _mapper.Map<OSMarketResearchJuryDto>(existing);
+        }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Service/Concrete/OSOfferLetterService.cs
+++ b/DogrudanTeminParadiseAPI/Service/Concrete/OSOfferLetterService.cs
@@ -1,0 +1,124 @@
+using AutoMapper;
+using DogrudanTeminParadiseAPI.Dto;
+using DogrudanTeminParadiseAPI.Models;
+using DogrudanTeminParadiseAPI.Repositories;
+using DogrudanTeminParadiseAPI.Service.Abstract;
+
+namespace DogrudanTeminParadiseAPI.Service.Concrete
+{
+    public class OSOfferLetterService : IOSOfferLetterService
+    {
+        private readonly MongoDBRepository<OSOfferLetter> _repo;
+        private readonly MongoDBRepository<Entreprise> _entRepo;
+        private readonly MongoDBRepository<OSProcurementEntry> _entryRepo;
+        private readonly IMapper _mapper;
+
+        public OSOfferLetterService(
+            MongoDBRepository<OSOfferLetter> repo,
+            MongoDBRepository<Entreprise> entRepo,
+            MongoDBRepository<OSProcurementEntry> entryRepo,
+            IMapper mapper)
+        {
+            _repo = repo;
+            _entRepo = entRepo;
+            _entryRepo = entryRepo;
+            _mapper = mapper;
+        }
+
+        public async Task<OSOfferLetterDto> CreateAsync(CreateOSOfferLetterDto dto)
+        {
+            var entry = await _entryRepo.GetByIdAsync(dto.OneSourceProcurementEntryId)
+                ?? throw new KeyNotFoundException("Entry bulunamadı.");
+            var entreprise = await _entRepo.GetByIdAsync(dto.EntrepriseId)
+                ?? throw new KeyNotFoundException("Firma bulunamadı.");
+
+            bool exists = (await _repo.GetAllAsync())
+                .Any(o => o.OneSourceProcurementEntryId == dto.OneSourceProcurementEntryId
+                       && o.EntrepriseId == dto.EntrepriseId);
+            if (exists)
+                throw new InvalidOperationException("Zaten oluşturulmuş.");
+
+            var entity = _mapper.Map<OSOfferLetter>(dto);
+            entity.Id = Guid.NewGuid();
+            await _repo.InsertAsync(entity);
+            return _mapper.Map<OSOfferLetterDto>(entity);
+        }
+
+        public async Task DeleteAsync(Guid id, Guid userId)
+        {
+            await _repo.DeleteAsync(id);
+        }
+
+        public async Task<IEnumerable<OSOfferLetterDto>> GetAllAsync()
+        {
+            var list = await _repo.GetAllAsync();
+            return list.Select(_mapper.Map<OSOfferLetterDto>);
+        }
+
+        public async Task<IEnumerable<OSOfferLetterDto>> GetAllAsync(IEnumerable<Guid> permittedEntryIds)
+        {
+            if (permittedEntryIds == null)
+                return Enumerable.Empty<OSOfferLetterDto>();
+            var list = await _repo.GetAllAsync();
+            return list.Where(o => permittedEntryIds.Contains(o.OneSourceProcurementEntryId))
+                       .Select(_mapper.Map<OSOfferLetterDto>);
+        }
+
+        public async Task<IEnumerable<OSOfferLetterDto>> GetAllByEntryAsync(Guid entryId)
+        {
+            var list = await _repo.GetAllAsync();
+            return list.Where(o => o.OneSourceProcurementEntryId == entryId)
+                       .Select(_mapper.Map<OSOfferLetterDto>);
+        }
+
+        public async Task<IEnumerable<OSOfferLetterDto>> GetAllByEntryAsync(Guid entryId, IEnumerable<Guid> permittedEntryIds)
+        {
+            if (permittedEntryIds == null || !permittedEntryIds.Contains(entryId))
+                return Enumerable.Empty<OSOfferLetterDto>();
+            var list = await _repo.GetAllAsync();
+            return list.Where(o => o.OneSourceProcurementEntryId == entryId)
+                       .Select(_mapper.Map<OSOfferLetterDto>);
+        }
+
+        public async Task<OSOfferLetterDto?> GetByIdAsync(Guid id)
+        {
+            var e = await _repo.GetByIdAsync(id);
+            return e == null ? null : _mapper.Map<OSOfferLetterDto>(e);
+        }
+
+        public async Task<OSOfferLetterDto?> UpdateAsync(Guid id, UpdateOSOfferLetterDto dto)
+        {
+            var existing = await _repo.GetByIdAsync(id);
+            if (existing == null) return null;
+            _mapper.Map(dto, existing);
+            await _repo.UpdateAsync(id, existing);
+            return _mapper.Map<OSOfferLetterDto>(existing);
+        }
+
+        public async Task<IEnumerable<OSOfferLetterDto>> UpdateItemsByEntryAsync(Guid entryId, UpdateOSOfferItemsByEntryDto dto)
+        {
+            if (entryId != dto.OneSourceProcurementEntryId)
+                throw new ArgumentException("Entry IDs do not match.", nameof(dto));
+            var all = await _repo.GetAllAsync();
+            var letters = all.Where(o => o.OneSourceProcurementEntryId == entryId).ToList();
+            if (!letters.Any())
+                throw new KeyNotFoundException("Bu entryId için teklif mektubu bulunamadı.");
+            var qtyMap = dto.Items.ToDictionary(i => i.OfferItemId, i => i.Qty);
+            foreach (var letter in letters)
+            {
+                var updated = false;
+                foreach (var item in letter.OfferItems)
+                {
+                    if (qtyMap.TryGetValue(item.Id, out var newQty))
+                    {
+                        item.Quantity = newQty;
+                        updated = true;
+                    }
+                }
+                if (updated)
+                    await _repo.UpdateAsync(letter.Id, letter);
+            }
+            return letters.Select(_mapper.Map<OSOfferLetterDto>);
+        }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Service/Concrete/OSProcurementEntryDocumentsService.cs
+++ b/DogrudanTeminParadiseAPI/Service/Concrete/OSProcurementEntryDocumentsService.cs
@@ -1,0 +1,74 @@
+using AutoMapper;
+using DogrudanTeminParadiseAPI.Dto;
+using DogrudanTeminParadiseAPI.Models;
+using DogrudanTeminParadiseAPI.Repositories;
+using DogrudanTeminParadiseAPI.Service.Abstract;
+
+namespace DogrudanTeminParadiseAPI.Service.Concrete
+{
+    public class OSProcurementEntryDocumentsService : IOSProcurementEntryDocumentsService
+    {
+        private readonly MongoDBRepository<OSProcurementEntryDocuments> _repo;
+        private readonly GridFSRepository _fsRepo;
+        private readonly IMapper _mapper;
+
+        public OSProcurementEntryDocumentsService(
+            MongoDBRepository<OSProcurementEntryDocuments> repo,
+            GridFSRepository fsRepo,
+            IMapper mapper)
+        {
+            _repo = repo;
+            _fsRepo = fsRepo;
+            _mapper = mapper;
+        }
+
+        public async Task<OSProcurementEntryDocumentsDto> CreateAsync(CreateOSProcurementEntryDocumentsDto dto)
+        {
+            var entity = new OSProcurementEntryDocuments
+            {
+                Id = Guid.NewGuid(),
+                OneSourceProcurementEntryId = dto.OneSourceProcurementEntryId,
+                TransactionAt = DateTime.UtcNow
+            };
+            foreach (var file in dto.EntrepriseFiles)
+            {
+                var fileId = await _fsRepo.UploadAsync(file, entity.Id + ".bin");
+                entity.EntrepriseFileIds.Add(fileId);
+            }
+            await _repo.InsertAsync(entity);
+            return _mapper.Map<OSProcurementEntryDocumentsDto>(entity);
+        }
+
+        public async Task DeleteAsync(Guid id)
+        {
+            await _repo.DeleteAsync(id);
+        }
+
+        public async Task<IEnumerable<OSProcurementEntryDocumentsDto>> GetAllByEntryAsync(Guid entryId)
+        {
+            var list = await _repo.GetAllAsync();
+            return list.Where(d => d.OneSourceProcurementEntryId == entryId)
+                       .Select(d => _mapper.Map<OSProcurementEntryDocumentsDto>(d));
+        }
+
+        public async Task<OSProcurementEntryDocumentsDto> GetByIdAsync(Guid id)
+        {
+            var entity = await _repo.GetByIdAsync(id);
+            return entity == null ? null : _mapper.Map<OSProcurementEntryDocumentsDto>(entity);
+        }
+
+        public async Task<OSProcurementEntryDocumentsDto> UpdateAsync(Guid id, UpdateOSProcurementEntryDocumentsDto dto)
+        {
+            var entity = await _repo.GetByIdAsync(id);
+            if (entity == null) return null;
+            entity.EntrepriseFileIds.Clear();
+            foreach (var file in dto.EntrepriseFiles)
+            {
+                var fileId = await _fsRepo.UploadAsync(file, entity.Id + ".bin");
+                entity.EntrepriseFileIds.Add(fileId);
+            }
+            await _repo.UpdateAsync(id, entity);
+            return _mapper.Map<OSProcurementEntryDocumentsDto>(entity);
+        }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Service/Concrete/OSProcurementEntryEditorService.cs
+++ b/DogrudanTeminParadiseAPI/Service/Concrete/OSProcurementEntryEditorService.cs
@@ -1,0 +1,56 @@
+using AutoMapper;
+using DogrudanTeminParadiseAPI.Dto;
+using DogrudanTeminParadiseAPI.Models;
+using DogrudanTeminParadiseAPI.Repositories;
+using DogrudanTeminParadiseAPI.Service.Abstract;
+
+namespace DogrudanTeminParadiseAPI.Service.Concrete
+{
+    public class OSProcurementEntryEditorService : IOSProcurementEntryEditorService
+    {
+        private readonly MongoDBRepository<OSProcurementEntryEditor> _repo;
+        private readonly IMapper _mapper;
+
+        public OSProcurementEntryEditorService(MongoDBRepository<OSProcurementEntryEditor> repo, IMapper mapper)
+        {
+            _repo = repo;
+            _mapper = mapper;
+        }
+
+        public async Task<OSProcurementEntryEditorDto> CreateAsync(CreateOSProcurementEntryEditorDto dto)
+        {
+            var entity = _mapper.Map<OSProcurementEntryEditor>(dto);
+            entity.Id = Guid.NewGuid();
+            await _repo.InsertAsync(entity);
+            return _mapper.Map<OSProcurementEntryEditorDto>(entity);
+        }
+
+        public async Task<OSProcurementEntryEditorDto> GetAsync()
+        {
+            var e = (await _repo.GetAllAsync()).FirstOrDefault();
+            return e == null ? null : _mapper.Map<OSProcurementEntryEditorDto>(e);
+        }
+
+        public async Task<OSProcurementEntryEditorDto> GetByIdAsync(Guid id)
+        {
+            var e = await _repo.GetByIdAsync(id);
+            return e == null ? null : _mapper.Map<OSProcurementEntryEditorDto>(e);
+        }
+
+        public async Task<OSProcurementEntryEditorDto> UpdateAsync(UpdateOSProcurementEntryEditorDto dto)
+        {
+            var e = (await _repo.GetAllAsync()).FirstOrDefault(o => o.OneSourceProcurementEntryId == dto.OneSourceProcurementEntryId);
+            if (e == null) return null;
+            _mapper.Map(dto, e);
+            await _repo.UpdateAsync(e.Id, e);
+            return _mapper.Map<OSProcurementEntryEditorDto>(e);
+        }
+
+        public async Task<OSProcurementEntryEditorDto> GetEditorByEntryIdAsync(Guid entryId)
+        {
+            var all = await _repo.GetAllAsync();
+            var editor = all.FirstOrDefault(o => o.OneSourceProcurementEntryId == entryId);
+            return _mapper.Map<OSProcurementEntryEditorDto>(editor);
+        }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Service/Concrete/OSProcurementEntryService.cs
+++ b/DogrudanTeminParadiseAPI/Service/Concrete/OSProcurementEntryService.cs
@@ -1,0 +1,51 @@
+using AutoMapper;
+using DogrudanTeminParadiseAPI.Dto;
+using DogrudanTeminParadiseAPI.Models;
+using DogrudanTeminParadiseAPI.Repositories;
+using DogrudanTeminParadiseAPI.Service.Abstract;
+
+namespace DogrudanTeminParadiseAPI.Service.Concrete
+{
+    public class OSProcurementEntryService : IOSProcurementEntryService
+    {
+        private readonly MongoDBRepository<OSProcurementEntry> _repo;
+        private readonly IMapper _mapper;
+
+        public OSProcurementEntryService(MongoDBRepository<OSProcurementEntry> repo, IMapper mapper)
+        {
+            _repo = repo;
+            _mapper = mapper;
+        }
+
+        public async Task<OSProcurementEntryDto> CreateAsync(CreateOSProcurementEntryDto dto)
+        {
+            var entity = _mapper.Map<OSProcurementEntry>(dto);
+            entity.Id = Guid.NewGuid();
+            await _repo.InsertAsync(entity);
+            return _mapper.Map<OSProcurementEntryDto>(entity);
+        }
+
+        public async Task DeleteAsync(Guid id)
+        {
+            await _repo.DeleteAsync(id);
+        }
+
+        public async Task<IEnumerable<OSProcurementEntryDto>> GetAllAsync()
+            => (await _repo.GetAllAsync()).Select(_mapper.Map<OSProcurementEntryDto>);
+
+        public async Task<OSProcurementEntryDto?> GetByIdAsync(Guid id)
+        {
+            var e = await _repo.GetByIdAsync(id);
+            return e == null ? null : _mapper.Map<OSProcurementEntryDto>(e);
+        }
+
+        public async Task<OSProcurementEntryDto?> UpdateAsync(Guid id, UpdateOSProcurementEntryDto dto)
+        {
+            var existing = await _repo.GetByIdAsync(id);
+            if (existing == null) return null;
+            _mapper.Map(dto, existing);
+            await _repo.UpdateAsync(id, existing);
+            return _mapper.Map<OSProcurementEntryDto>(existing);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement OSProcurementEntry model and related DTOs
- add editor/service/controller for OSProcurementEntry and editor
- save OSProcurementEntryDocuments in GridFS via new repository
- wire up new repositories and services in Program

## Testing
- `dotnet build DogrudanTeminParadiseAPI/DogrudanTeminParadiseAPI.sln -c Release` *(fails: `dotnet` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6881fcd102588323a24172fda6e63902