### PR TITLE
Add UserAvatar module with default avatar

### DIFF
--- a/DogrudanTeminParadiseAPI/Controllers/UserAvatarController.cs
+++ b/DogrudanTeminParadiseAPI/Controllers/UserAvatarController.cs
@@ -1,0 +1,39 @@
+using DogrudanTeminParadiseAPI.Dto;
+using DogrudanTeminParadiseAPI.Helpers.Attributes;
+using DogrudanTeminParadiseAPI.Service.Abstract;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DogrudanTeminParadiseAPI.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    [Authorize]
+    [CallLogs]
+    public class UserAvatarController : ControllerBase
+    {
+        private readonly IUserAvatarService _svc;
+        public UserAvatarController(IUserAvatarService svc) => _svc = svc;
+
+        [HttpPost]
+        public async Task<IActionResult> Create([FromBody] CreateUserAvatarDto dto)
+        {
+            var created = await _svc.CreateAsync(dto);
+            return CreatedAtAction(nameof(GetByUserOrAdminId), new { userOrAdminId = created.UserOrAdminId }, created);
+        }
+
+        [HttpGet("{userOrAdminId}")]
+        public async Task<IActionResult> GetByUserOrAdminId(Guid userOrAdminId)
+        {
+            var dto = await _svc.GetByUserOrAdminIdAsync(userOrAdminId);
+            return dto == null ? NotFound() : Ok(dto);
+        }
+
+        [HttpPut("{userOrAdminId}")]
+        public async Task<IActionResult> Update(Guid userOrAdminId, [FromBody] UpdateUserAvatarDto dto)
+        {
+            var updated = await _svc.UpdateAsync(userOrAdminId, dto);
+            return updated == null ? NotFound() : Ok(updated);
+        }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Dto/CreateUserAvatarDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/CreateUserAvatarDto.cs
@@ -1,0 +1,8 @@
+namespace DogrudanTeminParadiseAPI.Dto
+{
+    public class CreateUserAvatarDto
+    {
+        public Guid UserOrAdminId { get; set; }
+        public int AvatarCode { get; set; } = 10;
+    }
+}

--- a/DogrudanTeminParadiseAPI/Dto/UpdateUserAvatarDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/UpdateUserAvatarDto.cs
@@ -1,0 +1,7 @@
+namespace DogrudanTeminParadiseAPI.Dto
+{
+    public class UpdateUserAvatarDto
+    {
+        public int AvatarCode { get; set; }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Dto/UserAvatarDto.cs
+++ b/DogrudanTeminParadiseAPI/Dto/UserAvatarDto.cs
@@ -1,0 +1,9 @@
+namespace DogrudanTeminParadiseAPI.Dto
+{
+    public class UserAvatarDto
+    {
+        public Guid Id { get; set; }
+        public Guid UserOrAdminId { get; set; }
+        public int AvatarCode { get; set; }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Filter/DbInstallationWizard.cs
+++ b/DogrudanTeminParadiseAPI/Filter/DbInstallationWizard.cs
@@ -33,7 +33,7 @@ namespace DogrudanTeminParadiseAPI.Filter
             "InspectionAcceptanceCertificates",
             "AdditionalInspectionAcceptanceCertificates",
             "ApproximateCostJuries", "ProcurementEntryEditors", "InspectionAcceptanceNotes",
-            "DecisionNumbers"
+            "DecisionNumbers", "UserAvatars"
         };
 
             // 2) Eksik koleksiyonları yarat

--- a/DogrudanTeminParadiseAPI/Mapping/MappingProfile.cs
+++ b/DogrudanTeminParadiseAPI/Mapping/MappingProfile.cs
@@ -204,6 +204,10 @@ namespace DogrudanTeminParadiseAPI.Mapping
             CreateMap<CreateNotificationDto, Notification>();
             CreateMap<Notification, NotificationDto>();
 
+            CreateMap<CreateUserAvatarDto, UserAvatar>();
+            CreateMap<UpdateUserAvatarDto, UserAvatar>();
+            CreateMap<UserAvatar, UserAvatarDto>();
+
             CreateMap<BudgetItem, BudgetItemCountDto>();
             CreateMap<BudgetItem, BudgetItemPaymentDto>();
             CreateMap<BudgetItem, BudgetItemOfferStatDto>();

--- a/DogrudanTeminParadiseAPI/Models/UserAvatar.cs
+++ b/DogrudanTeminParadiseAPI/Models/UserAvatar.cs
@@ -1,0 +1,17 @@
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace DogrudanTeminParadiseAPI.Models
+{
+    public class UserAvatar
+    {
+        [BsonId]
+        [BsonRepresentation(BsonType.String)]
+        public Guid Id { get; set; }
+
+        [BsonRepresentation(BsonType.String)]
+        public Guid UserOrAdminId { get; set; }
+
+        public int AvatarCode { get; set; }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Program.cs
+++ b/DogrudanTeminParadiseAPI/Program.cs
@@ -86,6 +86,7 @@ builder.Services.AddScoped(sp => new MongoDBRepository<SharedProcurementEntry>(c
 builder.Services.AddScoped(sp => new MongoDBRepository<UserNotification>(cfg["MongoAPI"], cfg["MongoDBName"], "UserNotifications"));
 builder.Services.AddScoped(sp => new MongoDBRepository<BackupUserNotification>(cfg["MongoAPI"], cfg["MongoBackupDBName"], "BackupUserNotifications"));
 builder.Services.AddScoped(sp => new MongoDBRepository<Notification>(cfg["MongoAPI"], cfg["MongoDBName"], "Notifications"));
+builder.Services.AddScoped(sp => new MongoDBRepository<UserAvatar>(cfg["MongoAPI"], cfg["MongoDBName"], "UserAvatars"));
 builder.Services.AddScoped(sp => new MongoDBRepository<OSProcurementEntryDocuments>(cfg["MongoAPI"], cfg["MongoDBName"], "OSProcurementEntryDocuments"));
 builder.Services.AddScoped(sp => new MongoDBRepository<OSProcurementEntry>(cfg["MongoAPI"], cfg["MongoDBName"], "OSProcurementEntries"));
 builder.Services.AddScoped(sp => new MongoDBRepository<OSProcurementEntryEditor>(cfg["MongoAPI"], cfg["MongoDBName"], "OSProcurementEntryEditors"));
@@ -149,6 +150,7 @@ builder.Services.AddScoped<ISharedProcurementEntryService, SharedProcurementEntr
 builder.Services.AddScoped<IUserNotificationService, UserNotificationService>();
 builder.Services.AddScoped<IBackupUserNotificationService, BackupUserNotificationService>();
 builder.Services.AddScoped<INotificationService, NotificationService>();
+builder.Services.AddScoped<IUserAvatarService, UserAvatarService>();
 builder.Services.AddScoped<IOSProcurementEntryDocumentsService, OSProcurementEntryDocumentsService>();
 builder.Services.AddScoped<IOSProcurementEntryService, OSProcurementEntryService>();
 builder.Services.AddScoped<IOSProcurementEntryEditorService, OSProcurementEntryEditorService>();

--- a/DogrudanTeminParadiseAPI/Service/Abstract/IUserAvatarService.cs
+++ b/DogrudanTeminParadiseAPI/Service/Abstract/IUserAvatarService.cs
@@ -1,0 +1,11 @@
+using DogrudanTeminParadiseAPI.Dto;
+
+namespace DogrudanTeminParadiseAPI.Service.Abstract
+{
+    public interface IUserAvatarService
+    {
+        Task<UserAvatarDto> CreateAsync(CreateUserAvatarDto dto);
+        Task<UserAvatarDto?> GetByUserOrAdminIdAsync(Guid userOrAdminId);
+        Task<UserAvatarDto?> UpdateAsync(Guid userOrAdminId, UpdateUserAvatarDto dto);
+    }
+}

--- a/DogrudanTeminParadiseAPI/Service/Concrete/AdminUserService.cs
+++ b/DogrudanTeminParadiseAPI/Service/Concrete/AdminUserService.cs
@@ -16,6 +16,7 @@ namespace DogrudanTeminParadiseAPI.Service.Concrete
         private readonly MongoDBRepository<AdminUser> _repo;
         private readonly MongoDBRepository<User> _userRepo;
         private readonly MongoDBRepository<Title> _titleRepo;
+        private readonly MongoDBRepository<UserAvatar> _avatarRepo;
         private readonly IMapper _mapper;
         private readonly IConfiguration _cfg;
 
@@ -23,12 +24,14 @@ namespace DogrudanTeminParadiseAPI.Service.Concrete
             MongoDBRepository<AdminUser> repo,
             MongoDBRepository<User> userRepo,
             MongoDBRepository<Title> titleRepo,
+            MongoDBRepository<UserAvatar> avatarRepo,
             IMapper mapper,
             IConfiguration cfg)
         {
             _repo = repo;
             _userRepo = userRepo;
             _titleRepo = titleRepo;
+            _avatarRepo = avatarRepo;
             _mapper = mapper;
             _cfg = cfg;
         }
@@ -70,6 +73,13 @@ namespace DogrudanTeminParadiseAPI.Service.Concrete
             };
 
             await _repo.InsertAsync(entity);
+            var avatar = new UserAvatar
+            {
+                Id = Guid.NewGuid(),
+                UserOrAdminId = entity.Id,
+                AvatarCode = 10
+            };
+            await _avatarRepo.InsertAsync(avatar);
 
             return new AdminUserDto
             {

--- a/DogrudanTeminParadiseAPI/Service/Concrete/UserAvatarService.cs
+++ b/DogrudanTeminParadiseAPI/Service/Concrete/UserAvatarService.cs
@@ -1,0 +1,57 @@
+using AutoMapper;
+using DogrudanTeminParadiseAPI.Dto;
+using DogrudanTeminParadiseAPI.Models;
+using DogrudanTeminParadiseAPI.Repositories;
+using DogrudanTeminParadiseAPI.Service.Abstract;
+using MongoDB.Driver;
+
+namespace DogrudanTeminParadiseAPI.Service.Concrete
+{
+    public class UserAvatarService : IUserAvatarService
+    {
+        private readonly MongoDBRepository<UserAvatar> _repo;
+        private readonly IMapper _mapper;
+
+        public UserAvatarService(MongoDBRepository<UserAvatar> repo, IMapper mapper)
+        {
+            _repo = repo;
+            _mapper = mapper;
+        }
+
+        public async Task<UserAvatarDto> CreateAsync(CreateUserAvatarDto dto)
+        {
+            var filter = Builders<UserAvatar>.Filter.Eq(x => x.UserOrAdminId, dto.UserOrAdminId);
+            var existingList = await _repo.GetAllAsync(filter);
+            var existing = existingList.FirstOrDefault();
+            if (existing != null)
+            {
+                existing.AvatarCode = dto.AvatarCode;
+                await _repo.UpdateAsync(existing.Id, existing);
+                return _mapper.Map<UserAvatarDto>(existing);
+            }
+            var entity = _mapper.Map<UserAvatar>(dto);
+            entity.Id = Guid.NewGuid();
+            await _repo.InsertAsync(entity);
+            return _mapper.Map<UserAvatarDto>(entity);
+        }
+
+        public async Task<UserAvatarDto?> GetByUserOrAdminIdAsync(Guid userOrAdminId)
+        {
+            var filter = Builders<UserAvatar>.Filter.Eq(x => x.UserOrAdminId, userOrAdminId);
+            var list = await _repo.GetAllAsync(filter);
+            var entity = list.FirstOrDefault();
+            return entity == null ? null : _mapper.Map<UserAvatarDto>(entity);
+        }
+
+        public async Task<UserAvatarDto?> UpdateAsync(Guid userOrAdminId, UpdateUserAvatarDto dto)
+        {
+            var filter = Builders<UserAvatar>.Filter.Eq(x => x.UserOrAdminId, userOrAdminId);
+            var list = await _repo.GetAllAsync(filter);
+            var existing = list.FirstOrDefault();
+            if (existing == null) return null;
+            existing.AvatarCode = dto.AvatarCode;
+            await _repo.UpdateAsync(existing.Id, existing);
+            return _mapper.Map<UserAvatarDto>(existing);
+        }
+    }
+}

--- a/DogrudanTeminParadiseAPI/Service/Concrete/UserService.cs
+++ b/DogrudanTeminParadiseAPI/Service/Concrete/UserService.cs
@@ -17,6 +17,7 @@ namespace DogrudanTeminParadiseAPI.Service.Concrete
         private readonly MongoDBRepository<AdminUser> _adminRepo;
         private readonly MongoDBRepository<SuperAdminUser> _sysRepo;
         private readonly MongoDBRepository<Title> _titleRepo;
+        private readonly MongoDBRepository<UserAvatar> _avatarRepo;
         private readonly IMapper _mapper;
         private readonly IConfiguration _cfg;
         private readonly byte[] _aesKey;
@@ -26,6 +27,7 @@ namespace DogrudanTeminParadiseAPI.Service.Concrete
             MongoDBRepository<AdminUser> adminRepo,
             MongoDBRepository<SuperAdminUser> sysRepo,
             MongoDBRepository<Title> titleRepo,
+            MongoDBRepository<UserAvatar> avatarRepo,
             IMapper mapper,
             IConfiguration cfg)
         {
@@ -34,6 +36,7 @@ namespace DogrudanTeminParadiseAPI.Service.Concrete
             _sysRepo = sysRepo;
             _mapper = mapper;
             _titleRepo = titleRepo;
+            _avatarRepo = avatarRepo;
             _cfg = cfg;
 
             // AES anahtarı appsettings.json'dan okunur (32 karakter)
@@ -85,6 +88,13 @@ namespace DogrudanTeminParadiseAPI.Service.Concrete
             superAdmins[0].AssignPermissionToAdmin = permissionsDict;
 
             await _repo.InsertAsync(entity);
+            var avatar = new UserAvatar
+            {
+                Id = Guid.NewGuid(),
+                UserOrAdminId = entity.Id,
+                AvatarCode = 10
+            };
+            await _avatarRepo.InsertAsync(avatar);
             await _sysRepo.UpdateAsync(superAdmins[0].Id, superAdmins[0]);
 
             // Decrypted DTO


### PR DESCRIPTION
## Summary
- add `UserAvatar` model, DTOs and mappings
- implement service and controller for user avatars
- register repository/service and collection creation
- set default avatar for new users and admins

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688227ed4b80832391e3602aca1c22e9